### PR TITLE
Refactor to allow customization of EventSource's HTTP client

### DIFF
--- a/src/main/kotlin/io/outfoxx/sunday/EventParser.kt
+++ b/src/main/kotlin/io/outfoxx/sunday/EventParser.kt
@@ -22,7 +22,7 @@ import okio.ByteString
 import kotlin.text.Charsets.UTF_8
 
 /**
- * Parses & Dispatches Server-Sent Events
+ * Parses & Dispatches Server-Sent Events.
  *
  * The parser supports two-modes:
  * * `push` -
@@ -35,6 +35,7 @@ import kotlin.text.Charsets.UTF_8
  */
 class EventParser {
 
+  // Dispatched event information.
   data class EventInfo(
     var retry: String? = null,
     var event: String? = null,
@@ -141,7 +142,7 @@ class EventParser {
     private const val CR = 0x0D.toByte()
     private val CRLF = ByteString.of(CR, LF)
 
-    class Peeker(source: BufferedSource) {
+    private class Peeker(source: BufferedSource) {
 
       var bytesPeeked = 0L
         private set

--- a/src/main/kotlin/io/outfoxx/sunday/OkHttpClients.kt
+++ b/src/main/kotlin/io/outfoxx/sunday/OkHttpClients.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday
+
+import okhttp3.OkHttpClient
+
+/**
+ * Copies the client, reconfiguring it for use with an [EventSource].
+ *
+ * @see [EventSource.httpReadTimeoutDefault]
+ */
+fun OkHttpClient.reconfiguredForEvents(): OkHttpClient =
+  newBuilder()
+    .readTimeout(EventSource.httpReadTimeoutDefault)
+    .retryOnConnectionFailure(false)
+    .build()

--- a/src/test/kotlin/EventParserTest.kt
+++ b/src/test/kotlin/EventParserTest.kt
@@ -244,7 +244,6 @@ class EventParserTest {
         val sliceSize = min(Random.nextInt(10), eventStream.length)
         val slice = eventStream.substring(0 until sliceSize)
         eventBuffers.add(slice.encodeUtf8())
-        println("SLICE:: ${slice.replace("\n", "\\n")}")
         eventStream = eventStream.substring(sliceSize)
       }
 

--- a/src/test/kotlin/EventSourceTest.kt
+++ b/src/test/kotlin/EventSourceTest.kt
@@ -63,18 +63,15 @@ class EventSourceTest {
     server.start()
     server.use {
 
-      val httpClient = OkHttpClient.Builder().build()
-
       val eventSource =
         EventSource(
           { headers ->
-            httpClient.newCall(
-              Request.Builder()
-                .url(server.url("/test"))
-                .headers(headers)
-                .build()
-            )
-          }
+            Request.Builder()
+              .url(server.url("/test"))
+              .headers(headers)
+              .build()
+          },
+          OkHttpClient().newBuilder().build()
         )
 
       val completed = CountDownLatch(1)
@@ -118,18 +115,15 @@ class EventSourceTest {
     server.start()
     server.use {
 
-      val httpClient = OkHttpClient.Builder().build()
-
       val eventSource =
         EventSource(
           { headers ->
-            httpClient.newCall(
-              Request.Builder()
-                .url(server.url("/test"))
-                .headers(headers)
-                .build()
-            )
-          }
+            Request.Builder()
+              .url(server.url("/test"))
+              .headers(headers)
+              .build()
+          },
+          OkHttpClient().newBuilder().build()
         )
 
       var event: EventSource.Event? = null
@@ -175,18 +169,15 @@ class EventSourceTest {
     server.start()
     server.use {
 
-      val httpClient = OkHttpClient.Builder().build()
-
       val eventSource =
         EventSource(
           { headers ->
-            httpClient.newCall(
-              Request.Builder()
-                .url(server.url("/test"))
-                .headers(headers)
-                .build()
-            )
-          }
+            Request.Builder()
+              .url(server.url("/test"))
+              .headers(headers)
+              .build()
+          },
+          OkHttpClient().newBuilder().build()
         )
 
       var event: EventSource.Event? = null
@@ -241,18 +232,15 @@ class EventSourceTest {
     server.start()
     server.use {
 
-      val httpClient = OkHttpClient.Builder().build()
-
       val eventSource =
         EventSource(
           { headers ->
-            httpClient.newCall(
-              Request.Builder()
-                .url(server.url("/test"))
-                .headers(headers)
-                .build()
-            )
+            Request.Builder()
+              .url(server.url("/test"))
+              .headers(headers)
+              .build()
           },
+          OkHttpClient().newBuilder().build(),
           retryTime = Duration.ofMillis(100)
         )
 
@@ -289,22 +277,20 @@ class EventSourceTest {
   @Test
   fun `test listener add & remove`() {
 
-    val httpClient = OkHttpClient.Builder().build()
-
     val eventSource =
       EventSource(
         { headers ->
-          httpClient.newCall(
-            Request.Builder()
-              .url("http://example.com")
-              .headers(headers)
-              .build()
-          )
-        }
+          Request.Builder()
+            .url("http://example.com")
+            .headers(headers)
+            .build()
+        },
+        OkHttpClient().newBuilder().build()
       )
 
-    eventSource.addEventListener("test") { }
-    eventSource.removeEventListener("test")
+    val handler: (EventSource.Event) -> Unit = { }
+    eventSource.addEventListener("test", handler)
+    eventSource.removeEventListener("test", handler)
 
     assertThat(eventSource.eventListeners.keys, empty())
   }
@@ -329,18 +315,15 @@ class EventSourceTest {
     server.start()
     server.use {
 
-      val httpClient = OkHttpClient.Builder().build()
-
       val eventSource =
         EventSource(
           { headers ->
-            httpClient.newCall(
-              Request.Builder()
-                .url(server.url("/test"))
-                .headers(headers)
-                .build()
-            )
-          }
+            Request.Builder()
+              .url(server.url("/test"))
+              .headers(headers)
+              .build()
+          },
+          OkHttpClient().newBuilder().build()
         )
 
       val completed = CountDownLatch(1)
@@ -379,18 +362,15 @@ class EventSourceTest {
     server.start()
     server.use {
 
-      val httpClient = OkHttpClient.Builder().build()
-
       val eventSource =
         EventSource(
           { headers ->
-            httpClient.newCall(
-              Request.Builder()
-                .url(server.url("/test"))
-                .headers(headers)
-                .build()
-            )
-          }
+            Request.Builder()
+              .url(server.url("/test"))
+              .headers(headers)
+              .build()
+          },
+          OkHttpClient().newBuilder().build()
         )
 
       val completed = CountDownLatch(1)
@@ -433,18 +413,15 @@ class EventSourceTest {
     server.start()
     server.use {
 
-      val httpClient = OkHttpClient.Builder().build()
-
       val eventSource =
         EventSource(
           { headers ->
-            httpClient.newCall(
-              Request.Builder()
-                .url(server.url("/test"))
-                .headers(headers)
-                .build()
-            )
-          }
+            Request.Builder()
+              .url(server.url("/test"))
+              .headers(headers)
+              .build()
+          },
+          OkHttpClient().newBuilder().build()
         )
 
       eventSource.use {
@@ -498,18 +475,15 @@ class EventSourceTest {
     server.start()
     server.use {
 
-      val httpClient = OkHttpClient.Builder().build()
-
       val eventSource =
         EventSource(
           { headers ->
-            httpClient.newCall(
-              Request.Builder()
-                .url(server.url("/test"))
-                .headers(headers)
-                .build()
-            )
+            Request.Builder()
+              .url(server.url("/test"))
+              .headers(headers)
+              .build()
           },
+          OkHttpClient().newBuilder().build(),
           retryTime = Duration.ofMillis(100)
         )
 
@@ -545,28 +519,20 @@ class EventSourceTest {
           """.trimMargin(),
           5
         )
-    )
-    server.enqueue(
-      MockResponse()
-        .setResponseCode(200)
-        .setBody("retry: 500\n\n")
-        .setBodyDelay(2, SECONDS)
+        .throttleBody(20, 2, SECONDS)
     )
     server.start()
     server.use {
 
-      val httpClient = OkHttpClient.Builder().build()
-
       val eventSource =
         EventSource(
           { headers ->
-            httpClient.newCall(
-              Request.Builder()
-                .url(server.url("/test"))
-                .headers(headers)
-                .build()
-            )
+            Request.Builder()
+              .url(server.url("/test"))
+              .headers(headers)
+              .build()
           },
+          OkHttpClient().newBuilder().build(),
           eventTimeout = Duration.ofMillis(500),
           eventTimeoutCheckInterval = Duration.ofMillis(100)
         )
@@ -584,7 +550,7 @@ class EventSourceTest {
       eventSource.use {
         eventSource.connect()
 
-        assertThat(completed.await(2, SECONDS), equalTo(true))
+        assertThat(completed.await(12, SECONDS), equalTo(true))
         assertThat(error?.reason, equalTo(EventTimeout))
       }
     }

--- a/src/test/kotlin/OkHttpRequestFactoryTest.kt
+++ b/src/test/kotlin/OkHttpRequestFactoryTest.kt
@@ -87,9 +87,9 @@ class OkHttpRequestFactoryTest {
     val requestFactory =
       OkHttpRequestFactory(
         URITemplate("http://example.com"),
-        httpClient,
-        specialEncoders,
-        specialDecoders
+        httpClient = httpClient,
+        mediaTypeEncoders = specialEncoders,
+        mediaTypeDecoders = specialDecoders
       )
     requestFactory.use {
 


### PR DESCRIPTION
The event source needs long lived connections and now accepts an `OkHttpClient` which can be configured with an extended read timeout.

This also changes the `RequstFactory.eventSource`  & `RequstFactory.eventSource` methods to give the `requestSupplier` the ability to add sugested headers; which was previously done internally.

#### Configuration
All `EventSource` defaults have been made mutable vars.

Additionally, the `OkHttpRequestFactory` constructor now accepts a specific `eventHttpClient` that is passed onto new `EventSource` instances. `eventHttpClient` defaults to copying the `httpClient` and reconfiguring it’s timeouts for use with an `EventSource`