### PR TITLE
Add JDK 11 HTTP Client implementation module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
         path: |
           core/build/reports/
           okhttp/build/reports/
+          jdk/build/reports/
 
   publish:
     runs-on: ubuntu-latest

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -193,6 +193,18 @@ subprojects {
                 """.trimIndent()
               )
             }
+
+            "sunday-jdk" -> {
+              name.set("Sunday - Kotlin - JDK 11 HTTP Client Implementation")
+              description.set(
+                """
+                  Sunday | The framework of REST for Kotlin
+                  
+                  The JDK 11 HTTP Client implementation uses the JDK 11 HTTP client
+                  to execute HTTP requests.
+                """.trimIndent()
+              )
+            }
           }
           url.set("https://github.com/outfoxx/sunday-kt")
 
@@ -278,7 +290,7 @@ githubRelease {
   draft(true)
   prerelease(!releaseVersion.matches("""^\d+\.\d+\.\d+$""".toRegex()))
   releaseAssets(
-    listOf("core", "okhttp").flatMap { module ->
+    listOf("core", "jdk", "okhttp").flatMap { module ->
       listOf("", "-javadoc", "-sources").map { suffix ->
         file("$rootDir/$module/build/libs/sunday-$module-$releaseVersion$suffix.jar")
       }

--- a/jdk/build.gradle.kts
+++ b/jdk/build.gradle.kts
@@ -1,0 +1,18 @@
+
+val slf4jVersion: String by project
+val kotlinCoroutinesVersion: String by project
+val jacksonVersion: String by project
+
+val okhttpVersion: String by project
+
+dependencies {
+
+  api(project(":sunday-core"))
+
+  implementation("org.slf4j:slf4j-api:$slf4jVersion")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$kotlinCoroutinesVersion")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk9:$kotlinCoroutinesVersion")
+  implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
+
+  testImplementation("com.squareup.okhttp3:mockwebserver:$okhttpVersion")
+}

--- a/jdk/src/main/kotlin/io/outfoxx/sunday/jdk/HttpRequests.kt
+++ b/jdk/src/main/kotlin/io/outfoxx/sunday/jdk/HttpRequests.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.jdk
+
+import io.outfoxx.sunday.http.Headers
+import java.net.http.HttpRequest
+
+internal fun HttpRequest.Builder.headers(headers: Headers) = apply {
+  headers.forEach { header(it.first, it.second) }
+}

--- a/jdk/src/main/kotlin/io/outfoxx/sunday/jdk/JdkRequest.kt
+++ b/jdk/src/main/kotlin/io/outfoxx/sunday/jdk/JdkRequest.kt
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.jdk
+
+import io.outfoxx.sunday.http.Headers
+import io.outfoxx.sunday.http.Method
+import io.outfoxx.sunday.http.Request
+import io.outfoxx.sunday.http.Response
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.onFailure
+import kotlinx.coroutines.channels.onSuccess
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.jdk9.collect
+import okio.Buffer
+import okio.BufferedSource
+import org.slf4j.LoggerFactory
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.net.http.HttpResponse.BodyHandler
+import java.net.http.HttpResponse.BodySubscriber
+import java.nio.ByteBuffer
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.Flow.Subscription
+
+/**
+ * JDK11 HTTP Client implementation of [Request].
+ */
+class JdkRequest(
+  private val request: HttpRequest,
+  private val httpClient: HttpClient,
+) : Request {
+
+  companion object {
+
+    private val logger = LoggerFactory.getLogger(JdkRequest::class.java)
+  }
+
+  override val method: Method by lazy {
+    Method.valueOf(request.method())
+  }
+
+  override val uri: URI by lazy {
+    request.uri()
+  }
+
+  override val headers: Headers by lazy {
+    request.headers().map().flatMap { entry -> entry.value.map { entry.key to it } }
+  }
+
+  override suspend fun body(): BufferedSource? {
+    val bodyPublisher = request.bodyPublisher().orElse(null) ?: return null
+    val requestBody = Buffer()
+    bodyPublisher.collect { requestBody.write(it) }
+    return requestBody
+  }
+
+  override suspend fun execute(): Response {
+    logger.debug("Executing")
+
+    val response =
+      httpClient
+        .sendAsync(request, BufferedSourceBodyHandler())
+        .await()
+
+    return JdkResponse(response, httpClient)
+  }
+
+  override fun start(): Flow<Request.Event> {
+    return callbackFlow {
+
+      logger.debug("Starting")
+
+      val future =
+        httpClient
+          .sendAsync(
+            request,
+            RequestEventBodyHandler(JdkRequest(request, httpClient), channel)
+          )
+
+      awaitClose { future.cancel(false) }
+    }
+  }
+
+  class BufferedSourceBodyHandler : BodyHandler<BufferedSource> {
+
+    class Subscriber : BodySubscriber<BufferedSource> {
+
+      private val buffer = Buffer()
+      private var bodyFuture = CompletableFuture<BufferedSource>()
+
+      override fun onSubscribe(subscription: Subscription) {
+        subscription.request(Long.MAX_VALUE)
+      }
+
+      override fun onNext(item: MutableList<ByteBuffer>) {
+        item.forEach { buffer.write(it) }
+      }
+
+      override fun onError(throwable: Throwable) {
+        bodyFuture.completeExceptionally(throwable)
+      }
+
+      override fun onComplete() {
+        bodyFuture.complete(buffer)
+      }
+
+      override fun getBody(): CompletionStage<BufferedSource> {
+        return bodyFuture
+      }
+
+    }
+
+    override fun apply(responseInfo: HttpResponse.ResponseInfo?): BodySubscriber<BufferedSource> =
+      Subscriber()
+
+  }
+
+  class RequestEventBodyHandler(
+    private val originalRequest: JdkRequest,
+    private val channel: SendChannel<Request.Event>,
+  ) : BodyHandler<Unit> {
+
+    companion object {
+
+      private val logger = LoggerFactory.getLogger(RequestEventBodyHandler::class.java)
+    }
+
+    class Subscriber(
+      private val channel: SendChannel<Request.Event>,
+    ) : BodySubscriber<Unit> {
+
+      val bodyFuture = CompletableFuture<Unit>()
+
+      override fun onSubscribe(subscription: Subscription) {
+        subscription.request(Long.MAX_VALUE)
+      }
+
+      override fun onNext(item: MutableList<ByteBuffer>) {
+        item.forEach { data ->
+          val dataBuffer = Buffer()
+          dataBuffer.write(data)
+
+          val dataEvent = Request.Event.Data(dataBuffer)
+
+          channel.trySend(dataEvent)
+            .onSuccess { logger.trace("Sent: data") }
+            .onFailure { logger.error("Failed to send: data") }
+        }
+      }
+
+      override fun onError(throwable: Throwable) {
+        bodyFuture.completeExceptionally(throwable)
+      }
+
+      override fun onComplete() {
+
+        val endEvent = Request.Event.End(emptyList())
+
+        channel.trySend(endEvent)
+          .onSuccess { logger.trace("Sent: end") }
+          .onFailure { logger.error("Failed to send: end") }
+
+        bodyFuture.complete(Unit)
+      }
+
+      override fun getBody(): CompletionStage<Unit> {
+        return bodyFuture
+      }
+
+    }
+
+    override fun apply(responseInfo: HttpResponse.ResponseInfo): BodySubscriber<Unit> {
+
+      val startEvent =
+        Request.Event.Start(
+          JdkResponseInfo(
+            responseInfo,
+            originalRequest,
+          )
+        )
+
+      channel.trySend(startEvent)
+        .onSuccess { logger.trace("Sent: start") }
+        .onFailure { logger.error("Failed to send: start") }
+
+      return Subscriber(channel)
+    }
+
+  }
+
+}

--- a/jdk/src/main/kotlin/io/outfoxx/sunday/jdk/JdkRequestFactory.kt
+++ b/jdk/src/main/kotlin/io/outfoxx/sunday/jdk/JdkRequestFactory.kt
@@ -1,0 +1,401 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.jdk
+
+import io.outfoxx.sunday.EventSource
+import io.outfoxx.sunday.MediaType
+import io.outfoxx.sunday.MediaType.Companion.AnyText
+import io.outfoxx.sunday.MediaType.Companion.JSON
+import io.outfoxx.sunday.MediaType.Companion.WWWFormUrlEncoded
+import io.outfoxx.sunday.RequestFactory
+import io.outfoxx.sunday.SundayError
+import io.outfoxx.sunday.SundayError.Reason.EventDecodingFailed
+import io.outfoxx.sunday.SundayError.Reason.InvalidBaseUri
+import io.outfoxx.sunday.SundayError.Reason.InvalidContentType
+import io.outfoxx.sunday.SundayError.Reason.NoData
+import io.outfoxx.sunday.SundayError.Reason.NoDecoder
+import io.outfoxx.sunday.SundayError.Reason.NoSupportedAcceptTypes
+import io.outfoxx.sunday.SundayError.Reason.NoSupportedContentTypes
+import io.outfoxx.sunday.SundayError.Reason.ResponseDecodingFailed
+import io.outfoxx.sunday.SundayError.Reason.UnexpectedEmptyResponse
+import io.outfoxx.sunday.URITemplate
+import io.outfoxx.sunday.http.HeaderNames.Accept
+import io.outfoxx.sunday.http.HeaderNames.ContentType
+import io.outfoxx.sunday.http.HeaderParameters
+import io.outfoxx.sunday.http.Headers
+import io.outfoxx.sunday.http.Method
+import io.outfoxx.sunday.http.Parameters
+import io.outfoxx.sunday.http.Request
+import io.outfoxx.sunday.http.Response
+import io.outfoxx.sunday.http.ValueResponse
+import io.outfoxx.sunday.http.contentLength
+import io.outfoxx.sunday.http.contentType
+import io.outfoxx.sunday.mediatypes.codecs.MediaTypeDecoders
+import io.outfoxx.sunday.mediatypes.codecs.MediaTypeEncoders
+import io.outfoxx.sunday.mediatypes.codecs.StructuredMediaTypeDecoder
+import io.outfoxx.sunday.mediatypes.codecs.TextMediaTypeDecoder
+import io.outfoxx.sunday.mediatypes.codecs.URLQueryParamsEncoder
+import io.outfoxx.sunday.mediatypes.codecs.decode
+import io.outfoxx.sunday.problems.NonStandardStatus
+import io.outfoxx.sunday.utils.from
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.onFailure
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import okio.buffer
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.zalando.problem.DefaultProblem
+import org.zalando.problem.Problem
+import org.zalando.problem.Status
+import org.zalando.problem.ThrowableProblem
+import java.io.Closeable
+import java.net.Authenticator
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpRequest.BodyPublishers
+import java.time.Duration
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.full.createType
+import kotlin.reflect.typeOf
+
+/**
+ * JDK11 HTTP Client implementation of [RequestFactory].
+ */
+class JdkRequestFactory(
+  private val baseURI: URITemplate,
+  private val httpClient: HttpClient = defaultHttpClient(),
+  val mediaTypeEncoders: MediaTypeEncoders = MediaTypeEncoders.default,
+  val mediaTypeDecoders: MediaTypeDecoders = MediaTypeDecoders.default,
+  private val requestTimeout: Duration = requestTimeoutDefault,
+  private val eventRequestTimeout: Duration = EventSource.eventTimeoutDefault
+) : RequestFactory(), Closeable {
+
+  companion object {
+
+    fun defaultHttpClient(authenticator: Authenticator? = null): HttpClient =
+      HttpClient.newBuilder()
+        .followRedirects(HttpClient.Redirect.NORMAL)
+        .apply {
+          authenticator?.let { authenticator(authenticator) }
+        }
+        .build()
+
+    val requestTimeoutDefault: Duration = Duration.ofSeconds(10)
+
+    private val logger = LoggerFactory.getLogger(JdkRequestFactory::class.java)
+
+    private val unacceptableStatusCodes = 400 until 600
+    private val emptyDataStatusCodes = setOf(204, 205)
+
+    private fun URI.replaceQuery(rawQuery: String?): URI {
+      val authorityPart = rawAuthority
+      val pathPart = rawPath ?: "/"
+      val queryPart = rawQuery?.let { "?$it" } ?: ""
+      val fragmentPart = rawFragment?.let { "#$it" } ?: ""
+      return URI.create("$scheme://$authorityPart$pathPart$queryPart$fragmentPart")
+    }
+  }
+
+  private val problemTypes = mutableMapOf<String, KClass<out Problem>>()
+
+  override fun registerProblem(typeId: String, problemType: KClass<out Problem>) {
+    problemTypes[typeId] = problemType
+  }
+
+  override suspend fun <B : Any> request(
+    method: Method,
+    pathTemplate: String,
+    pathParameters: Parameters?,
+    queryParameters: Parameters?,
+    body: B?,
+    contentTypes: List<MediaType>?,
+    acceptTypes: List<MediaType>?,
+    headers: Parameters?,
+    purpose: RequestPurpose
+  ): Request {
+    logger.trace("Building request")
+
+    var uri =
+      try {
+        baseURI.resolve(pathTemplate, pathParameters).toURI()
+      } catch (x: Throwable) {
+        throw SundayError(InvalidBaseUri, cause = x)
+      }
+
+    if (!queryParameters.isNullOrEmpty()) {
+
+      // Encode & add query parameters to url
+
+      val urlQueryEncoder = mediaTypeEncoders.find(WWWFormUrlEncoded)
+        ?: throw SundayError(NoDecoder, WWWFormUrlEncoded.value)
+
+      urlQueryEncoder as? URLQueryParamsEncoder
+        ?: throw SundayError(
+          NoDecoder,
+          "'$WWWFormUrlEncoded' encoder must implement ${URLQueryParamsEncoder::class.simpleName}"
+        )
+
+      val uriQuery = urlQueryEncoder.encodeQueryString(queryParameters)
+
+      uri = uri.replaceQuery(uriQuery)
+    }
+
+    val requestBuilder = HttpRequest.newBuilder(uri)
+
+    HeaderParameters.encode(headers).forEach { (headerName, headerValue) ->
+      requestBuilder.header(headerName, headerValue)
+    }
+
+    // Add `Accept` header based on accept types
+    if (acceptTypes != null) {
+      val supportedAcceptTypes = acceptTypes.filter(mediaTypeDecoders::supports)
+      if (supportedAcceptTypes.isEmpty()) {
+        throw SundayError(NoSupportedAcceptTypes)
+      }
+
+      val accept = supportedAcceptTypes.joinToString(" , ") { it.toString() }
+
+      requestBuilder.header(Accept, accept)
+    }
+
+    val contentType = contentTypes?.firstOrNull(mediaTypeEncoders::supports)
+
+    // Add `Content-Type` header (even if body is null, to match any expected server requirements)
+    contentType?.let { requestBuilder.header(ContentType, contentType.toString()) }
+
+    var requestBodyPublisher = body?.let {
+      contentType ?: throw SundayError(NoSupportedContentTypes)
+
+      val mediaTypeEncoder = mediaTypeEncoders.find(contentType)
+        ?: error("Cannot find encoder that was reported as supported")
+
+      val encodedBody = mediaTypeEncoder.encode(body)
+
+      BodyPublishers.ofInputStream { encodedBody.buffer().inputStream() }
+    }
+
+    if (requestBodyPublisher == null && method.requiresBody) {
+      requestBodyPublisher = BodyPublishers.ofByteArray(byteArrayOf())
+    }
+
+    val request =
+      requestBuilder
+        .method(method.name, requestBodyPublisher ?: BodyPublishers.noBody())
+        .timeout(
+          when (purpose) {
+            RequestPurpose.Normal -> requestTimeout
+            RequestPurpose.Events -> eventRequestTimeout
+          }
+        )
+        .build()
+
+    logger.debug("Built request: {}", request)
+
+    return JdkRequest(request, httpClient)
+  }
+
+  override suspend fun response(request: Request): Response {
+    logger.debug("Initiating request")
+
+    return request.execute()
+  }
+
+  override suspend fun <B : Any, R : Any> result(
+    method: Method,
+    pathTemplate: String,
+    pathParameters: Parameters?,
+    queryParameters: Parameters?,
+    body: B?,
+    contentTypes: List<MediaType>?,
+    acceptTypes: List<MediaType>?,
+    headers: Parameters?,
+    resultType: KType
+  ): ValueResponse<R> {
+
+    val response =
+      response(
+        method,
+        pathTemplate,
+        pathParameters,
+        queryParameters,
+        body,
+        contentTypes,
+        acceptTypes,
+        headers
+      )
+
+    if (unacceptableStatusCodes.contains(response.statusCode)) {
+      throw parseFailure(response)
+    }
+
+    return ValueResponse(parseSuccess(response, resultType), response)
+  }
+
+  override fun eventSource(requestSupplier: suspend (Headers) -> Request): EventSource {
+
+    return EventSource(requestSupplier)
+  }
+
+  override fun <D : Any> eventStream(
+    decoder: (TextMediaTypeDecoder, String?, String?, String, Logger) -> D?,
+    requestSupplier: suspend (Headers) -> Request
+  ): Flow<D> = callbackFlow {
+
+    val jsonDecoder = mediaTypeDecoders.find(JSON) ?: throw SundayError(NoDecoder, JSON.value)
+    jsonDecoder as TextMediaTypeDecoder
+
+    val eventSource = eventSource(requestSupplier)
+
+    eventSource.onMessage = { event ->
+
+      val data = event.data
+      if (data != null) {
+
+        try {
+
+          val decodedEvent = decoder(jsonDecoder, event.event, event.id, data, logger)
+          if (decodedEvent != null) {
+
+            trySendBlocking(decodedEvent)
+              .onFailure {
+                cancel("Event send failed", it)
+              }
+
+          }
+
+        } catch (x: Throwable) {
+          cancel("Event decoding failed", SundayError(EventDecodingFailed, cause = x))
+        }
+
+      }
+
+    }
+
+    eventSource.onError = { error ->
+      logger.warn("EventSource error encountered", error)
+    }
+
+    eventSource.connect()
+
+    awaitClose { eventSource.close() }
+  }
+
+  override fun close() {
+    close(true)
+  }
+
+  override fun close(cancelOutstandingRequests: Boolean) {
+    // TODO track outstanding requests and implement appropriately
+  }
+
+  private fun <T : Any> parseSuccess(response: Response, resultType: KType): T {
+    logger.trace("Parsing success response")
+
+    val body = response.body
+    if (emptyDataStatusCodes.contains(response.statusCode)) {
+      if (resultType != typeOf<Unit>()) {
+        throw SundayError(UnexpectedEmptyResponse)
+      }
+      @Suppress("UNCHECKED_CAST")
+      return Unit as T
+    }
+
+    if (body == null || response.contentLength == 0L) {
+      throw SundayError(NoData)
+    }
+
+    val contentType =
+      response.contentType?.let { MediaType.from(it.toString()) }
+        ?: throw SundayError(InvalidContentType, response.contentType?.value ?: "")
+
+    val contentTypeDecoder = mediaTypeDecoders.find(contentType)
+      ?: throw SundayError(NoDecoder, contentType.value)
+
+    try {
+
+      return contentTypeDecoder.decode(body, resultType)
+    } catch (x: Throwable) {
+      throw SundayError(ResponseDecodingFailed, cause = x)
+    }
+  }
+
+  private fun parseFailure(response: Response): ThrowableProblem {
+    logger.trace("Parsing failure response")
+
+    val status =
+      try {
+        Status.valueOf(response.statusCode)
+      } catch (ignored: IllegalArgumentException) {
+        NonStandardStatus(response)
+      }
+
+    val body = response.body
+
+    return if (body != null && response.contentLength != 0L) {
+
+      val contentType =
+        response.contentType?.let { MediaType.from(it.toString()) }
+          ?: MediaType.OctetStream
+
+      if (!contentType.compatible(MediaType.Problem)) {
+        val (responseText, responseData) =
+          if (contentType.compatible(AnyText))
+            body.readString(Charsets.from(contentType)) to null
+          else
+            null to body.readByteArray()
+
+        Problem.builder()
+          .withStatus(status)
+          .withTitle(status.reasonPhrase)
+          .apply {
+            if (responseText != null) {
+              with("responseText", responseText)
+            }
+            if (responseData != null) {
+              with("responseData", responseData)
+            }
+          }
+          .build()
+      } else {
+
+        val problemDecoder =
+          mediaTypeDecoders.find(MediaType.Problem)
+            ?: throw SundayError(NoDecoder, MediaType.Problem.value)
+
+        problemDecoder as? StructuredMediaTypeDecoder
+          ?: throw SundayError(
+            NoDecoder,
+            "'${MediaType.Problem}' decoder must support structured decoding"
+          )
+
+        val decoded: Map<String, Any> = problemDecoder.decode(body)
+
+        val problemType = decoded["type"]?.toString() ?: ""
+        val problemClass = (problemTypes[problemType] ?: DefaultProblem::class).createType()
+
+        problemDecoder.decode(decoded, problemClass)
+      }
+    } else {
+      Problem.valueOf(status)
+    }
+  }
+}

--- a/jdk/src/main/kotlin/io/outfoxx/sunday/jdk/JdkResponse.kt
+++ b/jdk/src/main/kotlin/io/outfoxx/sunday/jdk/JdkResponse.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.jdk
+
+import io.outfoxx.sunday.http.Headers
+import io.outfoxx.sunday.http.Request
+import io.outfoxx.sunday.http.Response
+import okio.BufferedSource
+import java.net.http.HttpClient
+import java.net.http.HttpResponse
+
+/**
+ * JDK11 HTTP Client implementation of [Response] based on [HttpResponse].
+ */
+class JdkResponse(
+  private val response: HttpResponse<BufferedSource>,
+  private val httpClient: HttpClient
+) : Response {
+
+  override val statusCode: Int
+    get() = response.statusCode()
+
+  override val reasonPhrase: String? by lazy {
+    ReasonPhrases.lookup(response.statusCode())
+  }
+
+  override val headers: Headers by lazy {
+    response.headers().map().flatMap { entry -> entry.value.map { entry.key to it } }
+  }
+
+  override val body: BufferedSource?
+    get() = response.body()
+
+  override val trailers: Headers?
+    get() = null
+
+  override val request: Request
+    get() = JdkRequest(response.request(), httpClient)
+
+}

--- a/jdk/src/main/kotlin/io/outfoxx/sunday/jdk/JdkResponseInfo.kt
+++ b/jdk/src/main/kotlin/io/outfoxx/sunday/jdk/JdkResponseInfo.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.jdk
+
+import io.outfoxx.sunday.http.Headers
+import io.outfoxx.sunday.http.Response
+import okio.BufferedSource
+import java.net.http.HttpResponse.ResponseInfo
+
+/**
+ * JDK11 HTTP Client implementation of [Response] based on [ResponseInfo].
+ */
+class JdkResponseInfo(
+  private val responseInfo: ResponseInfo,
+  override val request: JdkRequest,
+) : Response {
+
+  override val statusCode: Int
+    get() = responseInfo.statusCode()
+
+  override val reasonPhrase: String? =
+    null
+
+  override val headers: Headers by lazy {
+    responseInfo.headers().map().flatMap { entry -> entry.value.map { entry.key to it } }
+  }
+
+  override val body: BufferedSource?
+    get() = null
+
+  override val trailers: Headers?
+    get() = null
+
+}

--- a/jdk/src/main/kotlin/io/outfoxx/sunday/jdk/ReasonPhrases.kt
+++ b/jdk/src/main/kotlin/io/outfoxx/sunday/jdk/ReasonPhrases.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.jdk
+
+object ReasonPhrases {
+
+  @Suppress("MagicNumber", "LongMethod")
+  fun lookup(statusCode: Int): String? {
+    return when (statusCode) {
+      100 -> "Continue"
+      101 -> "Switching Protocols"
+      102 -> "Processing"
+      103 -> "Early Hints"
+
+      200 -> "OK"
+      201 -> "Created"
+      202 -> "Accepted"
+      203 -> "Non-Authoritative Information"
+      204 -> "No Content"
+      205 -> "Reset Content"
+      206 -> "Partial Content"
+      207 -> "Multi-Status"
+      208 -> "Already Reported"
+      226 -> "IM Used"
+
+      300 -> "Multiple Choices"
+      301 -> "Moved Permanently"
+      302 -> "Moved Temporarily"
+      303 -> "See Other"
+      304 -> "Not Modified"
+      305 -> "Use Proxy"
+      306 -> "Switch Proxy"
+      307 -> "Temporary Redirect"
+      308 -> "Permanent Redirect"
+
+      400 -> "Bad Request"
+      401 -> "Unauthorized"
+      402 -> "Payment Required"
+      403 -> "Forbidden"
+      404 -> "Not Found"
+      405 -> "Method Not Allowed"
+      406 -> "Not Acceptable"
+      407 -> "Proxy Authentication Required"
+      408 -> "Request Timeout"
+      409 -> "Conflict"
+      410 -> "Gone"
+      411 -> "Length Required"
+      412 -> "Precondition Failed"
+      413 -> "Payload Too Large"
+      414 -> "URI Too Long"
+      415 -> "Unsupported Media Type"
+      416 -> "Range Not Satisfiable"
+      417 -> "Expectation Failed"
+      418 -> "I'm a teapot"
+      421 -> "Misdirected Request"
+      422 -> "Unprocessable Entity"
+      423 -> "Locked"
+      424 -> "Failed Dependency"
+      425 -> "Too Early"
+      426 -> "Upgrade Required"
+      428 -> "Precondition Required"
+      429 -> "Too Many Requests"
+      431 -> "Request Header Fields Too Large"
+      451 -> "Unavailable For Legal Reasons"
+
+      500 -> "Server Error"
+      501 -> "Not Implemented"
+      502 -> "Bad Gateway"
+      503 -> "Service Unavailable"
+      504 -> "Gateway Timeout"
+      505 -> "HTTP Version Not Supported"
+      506 -> "Variant Also Negotiates"
+      507 -> "Insufficient Storage"
+      508 -> "Loop Detected"
+      510 -> "Not Extended"
+      511 -> "Network Authentication Required"
+
+      else -> null
+    }
+  }
+}

--- a/jdk/src/test/kotlin/io/outfoxx/sunday/jdk/JdkEventSourceTest.kt
+++ b/jdk/src/test/kotlin/io/outfoxx/sunday/jdk/JdkEventSourceTest.kt
@@ -1,0 +1,574 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.jdk
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.outfoxx.sunday.EventSource
+import io.outfoxx.sunday.EventSourceError
+import io.outfoxx.sunday.EventSourceError.Reason.EventTimeout
+import io.outfoxx.sunday.MediaType.Companion.EventStream
+import io.outfoxx.sunday.http.HeaderNames.ContentType
+import io.outfoxx.sunday.http.HeaderNames.LastEventId
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.empty
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.not
+import org.hamcrest.Matchers.nullValue
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit.MILLISECONDS
+import java.util.concurrent.TimeUnit.SECONDS
+
+@Timeout(30)
+class JdkEventSourceTest {
+
+  @Test
+  fun `test ignore double connect`() {
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .addHeader(ContentType, EventStream)
+        .setChunkedBody(
+          """
+          |data: some test data
+          |
+          |
+          """.trimMargin(),
+          5
+        )
+        .setBodyDelay(500, MILLISECONDS)
+    )
+    server.start()
+    server.use {
+
+      val eventSource =
+        EventSource(
+          { headers ->
+            JdkRequest(
+              HttpRequest.newBuilder(server.url("/test").toUri())
+                .apply {
+                  headers.forEach { header(it.first, it.second) }
+                }
+                .build(),
+              HttpClient.newHttpClient(),
+            )
+          },
+        )
+
+      val completed = CountDownLatch(1)
+
+      eventSource.onMessage = { _ ->
+        try {
+          eventSource.close()
+        } finally {
+          completed.countDown()
+        }
+      }
+
+      eventSource.use {
+
+        eventSource.connect()
+        eventSource.connect()
+
+        assertTrue(completed.await(3, SECONDS))
+      }
+    }
+  }
+
+  @Test
+  fun `test simple data`() {
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .addHeader(ContentType, EventStream)
+        .setChunkedBody(
+          """
+          |event: test
+          |id: 123
+          |data: some test data
+          |
+          |
+          """.trimMargin(),
+          5
+        )
+    )
+    server.start()
+    server.use {
+
+      val eventSource =
+        EventSource(
+          { headers ->
+            JdkRequest(
+              HttpRequest.newBuilder(server.url("/test").toUri())
+                .headers(headers)
+                .build(),
+              HttpClient.newHttpClient(),
+            )
+          },
+        )
+
+      var event: EventSource.Event? = null
+      val completed = CountDownLatch(1)
+      eventSource.onMessage = {
+        event = it
+        completed.countDown()
+      }
+
+      eventSource.use {
+
+        eventSource.connect()
+
+        assertTrue(completed.await(300, SECONDS))
+        assertThat(event, not(nullValue()))
+        assertThat(event?.id, equalTo("123"))
+        assertThat(event?.event, equalTo("test"))
+        assertThat(event?.origin, equalTo(server.url("/test").toString()))
+        assertThat(event?.data, equalTo("some test data"))
+      }
+    }
+  }
+
+  @Test
+  fun `test JSON data`() {
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .addHeader(ContentType, EventStream)
+        .setChunkedBody(
+          """
+          |event: test
+          |id: 123
+          |data: {"some":
+          |data: "test data"}
+          |
+          |
+          """.trimMargin(),
+          5
+        )
+    )
+    server.start()
+    server.use {
+
+      val eventSource =
+        EventSource(
+          { headers ->
+            JdkRequest(
+              HttpRequest.newBuilder(server.url("/test").toUri())
+                .headers(headers)
+                .build(),
+              HttpClient.newHttpClient(),
+            )
+          },
+        )
+
+      var event: EventSource.Event? = null
+      val completed = CountDownLatch(1)
+      eventSource.onMessage = {
+        event = it
+        completed.countDown()
+      }
+
+      eventSource.use {
+
+        eventSource.connect()
+
+        assertTrue(completed.await(3, SECONDS))
+
+        assertThat(event, not(nullValue()))
+        assertThat(event?.id, equalTo("123"))
+        assertThat(event?.event, equalTo("test"))
+        assertThat(event?.origin, equalTo(server.url("/test").toString()))
+
+        val json =
+          try {
+            ObjectMapper().readValue<Map<String, String>>(event?.data ?: "{}")
+          } catch (t: Throwable) {
+            fail("Event contains invalid JSON", t)
+          }
+        assertThat(json, equalTo(mapOf("some" to "test data")))
+      }
+    }
+  }
+
+  @Test
+  fun `test callbacks`() {
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .addHeader(ContentType, EventStream)
+        .setBody(
+          """
+          |data: some test data
+          |
+          |
+          """.trimMargin(),
+        )
+    )
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(400)
+        .setHeader(ContentType, EventStream)
+    )
+    server.start()
+    server.use {
+
+      val eventSource =
+        EventSource(
+          { headers ->
+            JdkRequest(
+              HttpRequest.newBuilder(server.url("/test").toUri())
+                .headers(headers)
+                .build(),
+              HttpClient.newHttpClient(),
+            )
+          },
+          retryTime = Duration.ofMillis(100)
+        )
+
+      val opened = CountDownLatch(1)
+      val messaged = CountDownLatch(1)
+      val errored = CountDownLatch(1)
+
+      eventSource.onOpen = {
+        opened.countDown()
+      }
+      assertThat(eventSource.onOpen, not(nullValue()))
+
+      eventSource.onMessage = { _ ->
+        messaged.countDown()
+      }
+      assertThat(eventSource.onMessage, not(nullValue()))
+
+      eventSource.onError = { _ ->
+        errored.countDown()
+      }
+      assertThat(eventSource.onError, not(nullValue()))
+
+      eventSource.use {
+
+        eventSource.connect()
+
+        assertTrue(opened.await(3, SECONDS), "Did not received open callback")
+        assertTrue(messaged.await(3, SECONDS), "Did not received message callback")
+        assertTrue(errored.await(3, SECONDS), "Did not received error callback")
+      }
+    }
+  }
+
+  @Test
+  fun `test listener add & remove`() {
+
+    val eventSource =
+      EventSource(
+        { headers ->
+          JdkRequest(
+            HttpRequest.newBuilder(URI("http://example.com"))
+              .headers(headers)
+              .build(),
+            HttpClient.newHttpClient(),
+          )
+        },
+      )
+
+    val handler: (EventSource.Event) -> Unit = { }
+    eventSource.addEventListener("test", handler)
+    eventSource.removeEventListener("test", handler)
+
+    assertThat(eventSource.eventListeners.keys, empty())
+  }
+
+  @Test
+  fun `valid retry timeout update`() {
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .addHeader(ContentType, EventStream)
+        .setChunkedBody(
+          """
+          |retry: 123456789
+          |data: some test data
+          |
+          |
+          """.trimMargin(),
+          5
+        )
+    )
+    server.start()
+    server.use {
+
+      val eventSource =
+        EventSource(
+          { headers ->
+            JdkRequest(
+              HttpRequest.newBuilder(server.url("/test").toUri())
+                .headers(headers)
+                .build(),
+              HttpClient.newHttpClient(),
+            )
+          },
+        )
+
+      val completed = CountDownLatch(1)
+
+      eventSource.onMessage = { _ ->
+        completed.countDown()
+      }
+
+      eventSource.use {
+
+        eventSource.connect()
+
+        assertTrue(completed.await(3, SECONDS))
+        assertThat(eventSource.retryTime, equalTo(Duration.ofMillis(123456789L)))
+      }
+    }
+  }
+
+  @Test
+  fun `invalid retry timeout updates are ignored`() {
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .addHeader(ContentType, EventStream)
+        .setChunkedBody(
+          """
+          |retry: long
+          |data: some test data
+          |
+          |
+          """.trimMargin(),
+          5
+        )
+    )
+    server.start()
+    server.use {
+
+      val eventSource =
+        EventSource(
+          { headers ->
+            JdkRequest(
+              HttpRequest.newBuilder(server.url("/test").toUri())
+                .headers(headers)
+                .build(),
+              HttpClient.newHttpClient(),
+            )
+          },
+        )
+
+      val completed = CountDownLatch(1)
+
+      eventSource.onMessage = { _ ->
+        completed.countDown()
+      }
+
+      eventSource.use {
+
+        eventSource.connect()
+
+        assertTrue(completed.await(3, SECONDS))
+        assertThat(eventSource.retryTime, equalTo(Duration.ofMillis(500L)))
+      }
+    }
+  }
+
+  @Test
+  fun `reconnect with last-event-id`() {
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .addHeader(ContentType, EventStream)
+        .setChunkedBody(
+          """
+          |id: 123-abc
+          |data: some test data
+          |
+          |
+          """.trimMargin(),
+          5
+        )
+    )
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(503)
+    )
+    server.start()
+    server.use {
+
+      val eventSource =
+        EventSource(
+          { headers ->
+            JdkRequest(
+              HttpRequest.newBuilder(server.url("/test").toUri())
+                .headers(headers)
+                .build(),
+              HttpClient.newHttpClient(),
+            )
+          },
+        )
+
+      eventSource.use {
+
+        eventSource.connect()
+
+        server.takeRequest(3, SECONDS)
+        val reconnectRequest = server.takeRequest(3, SECONDS)
+
+        assertThat(reconnectRequest, not(nullValue()))
+        assertThat(reconnectRequest?.getHeader(LastEventId), equalTo("123-abc"))
+      }
+    }
+  }
+
+  @Test
+  fun `reconnect with last-event-id ignores invalid ids`() {
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .addHeader(ContentType, EventStream)
+        .setChunkedBody(
+          """
+          |id: 123-abc
+          |data: some test data
+          |
+          |
+          """.trimMargin(),
+          5
+        )
+    )
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .addHeader(ContentType, EventStream)
+        .setChunkedBody(
+          """
+          |id: 456${0.toChar()}def
+          |data: some test data
+          |
+          |
+          """.trimMargin(),
+          5
+        )
+    )
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(503)
+    )
+    server.start()
+    server.use {
+
+      val eventSource =
+        EventSource(
+          { headers ->
+            JdkRequest(
+              HttpRequest.newBuilder(server.url("/test").toUri())
+                .headers(headers)
+                .build(),
+              HttpClient.newHttpClient(),
+            )
+          },
+          retryTime = Duration.ofMillis(100)
+        )
+
+      eventSource.use {
+
+        eventSource.connect()
+
+        server.takeRequest(3, SECONDS)
+        val reconnect1 = server.takeRequest(3, SECONDS)
+        val reconnect2 = server.takeRequest(3, SECONDS)
+
+        assertThat(reconnect1, not(nullValue()))
+        assertThat(reconnect1?.getHeader(LastEventId), equalTo("123-abc"))
+
+        assertThat(reconnect2, not(nullValue()))
+        assertThat(reconnect2?.getHeader(LastEventId), equalTo("123-abc"))
+      }
+    }
+  }
+
+  @Test
+  fun `event timeout reconnects`() {
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .addHeader(ContentType, EventStream)
+        .setChunkedBody(
+          """
+          |data: some test data
+          |
+          |
+          """.trimMargin(),
+          5
+        )
+        .throttleBody(20, 2, SECONDS)
+    )
+    server.start()
+    server.use {
+
+      val eventSource =
+        EventSource(
+          { headers ->
+            JdkRequest(
+              HttpRequest.newBuilder(server.url("/test").toUri())
+                .headers(headers)
+                .build(),
+              HttpClient.newHttpClient(),
+            )
+          },
+          eventTimeout = Duration.ofMillis(500),
+          eventTimeoutCheckInterval = Duration.ofMillis(100)
+        )
+
+      val completed = CountDownLatch(1)
+
+      var error: EventSourceError? = null
+      eventSource.onError = {
+        if (it is EventSourceError) {
+          error = it
+          completed.countDown()
+        }
+      }
+
+      eventSource.use {
+        eventSource.connect()
+
+        assertThat(completed.await(12, SECONDS), equalTo(true))
+        assertThat(error?.reason, equalTo(EventTimeout))
+      }
+    }
+  }
+
+}

--- a/jdk/src/test/kotlin/io/outfoxx/sunday/jdk/JdkRequestFactoryTest.kt
+++ b/jdk/src/test/kotlin/io/outfoxx/sunday/jdk/JdkRequestFactoryTest.kt
@@ -1,0 +1,964 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.jdk
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.outfoxx.sunday.MediaType
+import io.outfoxx.sunday.MediaType.Companion.CBOR
+import io.outfoxx.sunday.MediaType.Companion.EventStream
+import io.outfoxx.sunday.MediaType.Companion.HTML
+import io.outfoxx.sunday.MediaType.Companion.JSON
+import io.outfoxx.sunday.MediaType.Companion.Problem
+import io.outfoxx.sunday.MediaType.Companion.WWWFormUrlEncoded
+import io.outfoxx.sunday.SundayError
+import io.outfoxx.sunday.SundayError.Reason.NoSupportedAcceptTypes
+import io.outfoxx.sunday.SundayError.Reason.NoSupportedContentTypes
+import io.outfoxx.sunday.URITemplate
+import io.outfoxx.sunday.http.HeaderNames
+import io.outfoxx.sunday.http.HeaderNames.ContentType
+import io.outfoxx.sunday.http.Method
+import io.outfoxx.sunday.mediatypes.codecs.BinaryEncoder
+import io.outfoxx.sunday.mediatypes.codecs.MediaTypeDecoders
+import io.outfoxx.sunday.mediatypes.codecs.MediaTypeEncoders
+import io.outfoxx.sunday.mediatypes.codecs.TextDecoder
+import io.outfoxx.sunday.mediatypes.codecs.URLQueryParamsEncoder
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeout
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.anEmptyMap
+import org.hamcrest.Matchers.contains
+import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasEntry
+import org.hamcrest.Matchers.hasItem
+import org.hamcrest.Matchers.nullValue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.zalando.problem.AbstractThrowableProblem
+import org.zalando.problem.DefaultProblem
+import org.zalando.problem.Status
+import org.zalando.problem.ThrowableProblem
+import java.net.URI
+import kotlin.coroutines.resume
+import kotlin.reflect.typeOf
+
+class JdkRequestFactoryTest {
+
+  companion object {
+
+    private val objectMapper =
+      ObjectMapper()
+        .findAndRegisterModules()
+  }
+
+  /**
+   * General
+   */
+
+  @Test
+  fun `allows overriding defaults constructor`() {
+
+    val specialEncoders = MediaTypeEncoders.Builder().build()
+    val specialDecoders = MediaTypeDecoders.Builder().build()
+
+    val requestFactory =
+      JdkRequestFactory(
+        URITemplate("http://example.com"),
+        mediaTypeEncoders = specialEncoders,
+        mediaTypeDecoders = specialDecoders
+      )
+    requestFactory.use {
+
+      assertThat(requestFactory.mediaTypeEncoders, equalTo(specialEncoders))
+      assertThat(requestFactory.mediaTypeDecoders, equalTo(specialDecoders))
+    }
+  }
+
+
+  /**
+   * Request Building
+   */
+
+  @Test
+  fun `encodes query parameters`() {
+
+    val requestFactory =
+      JdkRequestFactory(
+        URITemplate("http://example.com", mapOf()),
+      )
+    requestFactory.use {
+
+      val request =
+        runBlocking {
+          requestFactory.request(
+            Method.Get,
+            "/encode-query-params",
+            pathParameters = null,
+            queryParameters = mapOf("limit" to 5, "search" to "1 & 2"),
+            body = null,
+            contentTypes = null,
+            acceptTypes = null,
+            headers = null
+          )
+        }
+
+      assertThat(
+        request.uri,
+        equalTo(URI("http://example.com/encode-query-params?limit=5&search=1%20%26%202"))
+      )
+    }
+  }
+
+  @Test
+  fun `fails when no query parameter encoder is registered and query params are provided`() {
+
+    val requestFactory =
+      JdkRequestFactory(
+        URITemplate("http://example.com", mapOf()),
+        mediaTypeEncoders = MediaTypeEncoders.Builder().build()
+      )
+    requestFactory.use {
+
+      val error =
+        assertThrows<SundayError> {
+          runBlocking {
+            requestFactory.request(
+              Method.Get,
+              "/encode-query-params",
+              queryParameters = mapOf("limit" to 5, "search" to "1 & 2")
+            )
+          }
+        }
+
+      assertThat(error.reason, equalTo(SundayError.Reason.NoDecoder))
+    }
+  }
+
+  @Test
+  fun `fails url query parameter encoder is not a URLQueryParamsEncoder`() {
+
+    val requestFactory =
+      JdkRequestFactory(
+        URITemplate("http://example.com", mapOf()),
+        mediaTypeEncoders = MediaTypeEncoders.Builder().register(BinaryEncoder(), WWWFormUrlEncoded)
+          .build()
+      )
+    requestFactory.use {
+
+      val error =
+        assertThrows<SundayError> {
+          runBlocking {
+            requestFactory.request(
+              Method.Get,
+              "/encode-query-params",
+              queryParameters = mapOf("limit" to 5, "search" to "1 & 2")
+            )
+          }
+        }
+
+      assertThat(error.reason, equalTo(SundayError.Reason.NoDecoder))
+      assertThat(error.message, containsString(URLQueryParamsEncoder::class.simpleName))
+    }
+  }
+
+  @Test
+  fun `adds custom headers`() {
+
+    val requestFactory =
+      JdkRequestFactory(
+        URITemplate("http://example.com", mapOf()),
+      )
+    requestFactory.use {
+
+      val request =
+        runBlocking {
+          requestFactory.request(
+            Method.Get,
+            "/add-custom-headers",
+            headers = mapOf(HeaderNames.Authorization to "Bearer 12345")
+          )
+        }
+
+      assertThat(request.headers, contains(HeaderNames.Authorization to "Bearer 12345"))
+    }
+  }
+
+  @Test
+  fun `adds accept headers`() {
+
+    val requestFactory =
+      JdkRequestFactory(
+        URITemplate("http://example.com", mapOf()),
+      )
+    requestFactory.use {
+
+      val request =
+        runBlocking {
+          requestFactory.request(
+            Method.Get,
+            "/add-accept-headers",
+            acceptTypes = listOf(JSON, CBOR)
+          )
+        }
+
+      assertThat(
+        request.headers,
+        contains(HeaderNames.Accept to "application/json , application/cbor")
+      )
+    }
+  }
+
+  @Test
+  fun `fails if none of the accept types has a decoder`() {
+
+    val requestFactory =
+      JdkRequestFactory(
+        URITemplate("http://example.com", mapOf()),
+        mediaTypeDecoders = MediaTypeDecoders.Builder().build()
+      )
+    requestFactory.use {
+
+      val error =
+        assertThrows<SundayError> {
+          runBlocking {
+            requestFactory.request(
+              Method.Get,
+              "/add-accept-headers",
+              acceptTypes = listOf(JSON, CBOR)
+            )
+          }
+        }
+
+      assertThat(error.reason, equalTo(NoSupportedAcceptTypes))
+    }
+  }
+
+  @Test
+  fun `fails if none of the content types has an encoder for the body`() {
+
+    val requestFactory =
+      JdkRequestFactory(
+        URITemplate("http://example.com", mapOf()),
+      )
+    requestFactory.use {
+
+      val error =
+        assertThrows<SundayError> {
+          runBlocking {
+            requestFactory.request(
+              Method.Post,
+              "/add-accept-headers",
+              body = "a body",
+              contentTypes = listOf(MediaType.from("application/x-unknown"))
+            )
+          }
+        }
+
+      assertThat(error.reason, equalTo(NoSupportedContentTypes))
+    }
+  }
+
+  @Test
+  fun `attaches encoded body based on content-type`() {
+
+    val requestFactory =
+      JdkRequestFactory(
+        URITemplate("http://example.com", mapOf()),
+      )
+    requestFactory.use {
+
+      val request =
+        runBlocking {
+          requestFactory.request(
+            Method.Post,
+            "/attach-body",
+            body = mapOf("a" to 5),
+            contentTypes = listOf(JSON)
+          )
+        }
+
+      val body = runBlocking { request.body() }
+      assertThat(body?.readByteArray(), equalTo("""{"a":5}""".encodeToByteArray()))
+    }
+  }
+
+  @Test
+  fun `set content-type when body is non-existent`() {
+
+    val requestFactory =
+      JdkRequestFactory(
+        URITemplate("http://example.com", mapOf()),
+      )
+    requestFactory.use {
+
+      val request =
+        runBlocking {
+          requestFactory.request(
+            Method.Post,
+            "/attach-body",
+            contentTypes = listOf(JSON)
+          )
+        }
+
+      assertThat(request.headers, contains(ContentType to "application/json"))
+    }
+  }
+
+  /**
+   * Response/Result Building
+   */
+
+  @Test
+  fun `fetches typed results`() {
+
+    data class Tester(
+      val name: String,
+      val count: Int
+    )
+
+    val tester = Tester("Test", 10)
+
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .addHeader(ContentType, JSON)
+        .setBody(objectMapper.writeValueAsString(tester))
+    )
+    server.start()
+    server.use {
+
+      val requestFactory =
+        JdkRequestFactory(
+          URITemplate(server.url("/").toString(), mapOf()),
+        )
+      requestFactory.use {
+
+        val result =
+          runBlocking {
+            requestFactory.result<Void, Tester>(
+              Method.Get,
+              "",
+              pathParameters = null,
+              queryParameters = null,
+              body = null,
+              contentTypes = null,
+              acceptTypes = null,
+              headers = null
+            )
+          }
+
+        assertThat(result.headers, hasItem(ContentType to "application/json"))
+        assertThat(result.value, equalTo(tester))
+      }
+    }
+  }
+
+  @Test
+  fun `executes requests with empty responses`() {
+
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(204)
+    )
+    server.start()
+    server.use {
+
+      val requestFactory =
+        JdkRequestFactory(
+          URITemplate(server.url("/").toString(), mapOf()),
+        )
+      requestFactory.use {
+
+        assertDoesNotThrow {
+          runBlocking {
+            requestFactory.result<Unit>(Method.Post, "")
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  fun `executes manual requests for responses`() {
+
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .setHeader(ContentType, JSON)
+        .setBody("[]")
+    )
+    server.start()
+    server.use {
+
+      val requestFactory =
+        JdkRequestFactory(
+          URITemplate(server.url("/").toString(), mapOf()),
+        )
+      requestFactory.use {
+
+        val response =
+          runBlocking {
+            requestFactory.response(Method.Get, "")
+          }
+
+        assertThat(response.body?.readByteArray(), equalTo("[]".encodeToByteArray()))
+      }
+    }
+  }
+
+  @Test
+  fun `error responses with non standard status codes are handled`() {
+
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setStatus("HTTP/1.1 484 Special Status")
+        .setHeader(ContentType, JSON)
+        .setBody("[]")
+    )
+    server.start()
+    server.use {
+
+      val requestFactory =
+        JdkRequestFactory(
+          URITemplate(server.url("/").toString(), mapOf()),
+        )
+      requestFactory.use {
+
+        val problem =
+          assertThrows<ThrowableProblem> {
+            runBlocking {
+              requestFactory.result<List<String>>(Method.Get, "")
+            }
+          }
+
+        assertThat(problem.status?.statusCode, equalTo(484))
+        assertThat(problem.status?.reasonPhrase, nullValue())
+        assertThat(problem.title, equalTo(problem.status?.reasonPhrase))
+      }
+    }
+  }
+
+  @Test
+  fun `fails when no data and non empty result types`() {
+
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(204)
+    )
+    server.start()
+    server.use {
+
+      val requestFactory =
+        JdkRequestFactory(
+          URITemplate(server.url("/").toString(), mapOf()),
+        )
+      requestFactory.use {
+
+        val error =
+          assertThrows<SundayError> {
+            runBlocking {
+              requestFactory.result<Array<String>>(Method.Get, "")
+            }
+          }
+
+        assertThat(error.reason, equalTo(SundayError.Reason.UnexpectedEmptyResponse))
+      }
+    }
+  }
+
+  @Test
+  fun `fails when a result is expected and no data is returned in response`() {
+
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+    )
+    server.start()
+    server.use {
+
+      val requestFactory =
+        JdkRequestFactory(
+          URITemplate(server.url("/").toString(), mapOf()),
+        )
+      requestFactory.use {
+
+        val error =
+          assertThrows<SundayError> {
+            runBlocking {
+              requestFactory.result<Array<String>>(Method.Get, "")
+            }
+          }
+
+        assertThat(error.reason, equalTo(SundayError.Reason.NoData))
+      }
+    }
+  }
+
+  @Test
+  fun `fails when response content-type is invalid`() {
+
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .setHeader(ContentType, "bad/x-unknown")
+        .setBody("some stuff")
+    )
+    server.start()
+    server.use {
+
+      val requestFactory =
+        JdkRequestFactory(
+          URITemplate(server.url("/").toString(), mapOf()),
+        )
+      requestFactory.use {
+
+        val error =
+          assertThrows<SundayError> {
+            runBlocking {
+              requestFactory.result<Array<String>>(Method.Get, "")
+            }
+          }
+
+        assertThat(error.reason, equalTo(SundayError.Reason.InvalidContentType))
+      }
+    }
+  }
+
+  @Test
+  fun `fails when response content-type is unsupported`() {
+
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .setHeader(ContentType, "application/x-unknown")
+        .setBody("some data")
+    )
+    server.start()
+    server.use {
+
+      val requestFactory =
+        JdkRequestFactory(
+          URITemplate(server.url("/").toString(), mapOf()),
+        )
+      requestFactory.use {
+
+        val error =
+          assertThrows<SundayError> {
+            runBlocking {
+              requestFactory.result<Array<String>>(Method.Get, "")
+            }
+          }
+
+        assertThat(error.reason, equalTo(SundayError.Reason.NoDecoder))
+      }
+    }
+  }
+
+  @Test
+  fun `test decoding fails when no decoder for content-type`() {
+
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .addHeader(ContentType, "application/x-unknown-type")
+        .setBody("<test>Test</Test>")
+    )
+    server.start()
+    server.use {
+
+      val requestFactory =
+        JdkRequestFactory(
+          URITemplate(server.url("/").toString(), mapOf()),
+        )
+      requestFactory.use {
+
+        val error =
+          assertThrows<SundayError> {
+            runBlocking { requestFactory.result<String>(Method.Get, "/problem") }
+          }
+
+        assertThat(error.reason, equalTo(SundayError.Reason.NoDecoder))
+      }
+    }
+  }
+
+  @Test
+  fun `test decoding errors are translated to SundayError`() {
+
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .addHeader(ContentType, JSON)
+        .setBody("<test>Test</Test>")
+    )
+    server.start()
+    server.use {
+
+      val requestFactory =
+        JdkRequestFactory(
+          URITemplate(server.url("/").toString(), mapOf()),
+        )
+      requestFactory.use {
+
+        val error =
+          assertThrows<SundayError> {
+            runBlocking { requestFactory.result<String>(Method.Get, "/problem") }
+          }
+
+        assertThat(error.reason, equalTo(SundayError.Reason.ResponseDecodingFailed))
+      }
+    }
+  }
+
+  /**
+   * Problem Building/Handling
+   */
+
+  @Test
+  fun `test registered problems decode as typed problems`() {
+
+    val testProblem = TestProblem("Some Extra", URI.create("id:12345"))
+
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(TestProblem.STATUS.statusCode)
+        .addHeader(ContentType, Problem)
+        .setBody(objectMapper.writeValueAsString(testProblem))
+    )
+    server.start()
+    server.use {
+
+      val requestFactory =
+        JdkRequestFactory(
+          URITemplate(server.url("/").toString(), mapOf()),
+        )
+      requestFactory.registerProblem(TestProblem.TYPE, TestProblem::class)
+      requestFactory.use {
+
+        val error =
+          assertThrows<TestProblem> {
+            runBlocking { requestFactory.result<String>(Method.Get, "/problem") }
+          }
+
+        assertThat(error.type, equalTo(testProblem.type))
+        assertThat(error.title, equalTo(testProblem.title))
+        assertThat(error.status, equalTo(testProblem.status))
+        assertThat(error.detail, equalTo(testProblem.detail))
+        assertThat(error.instance, equalTo(testProblem.instance))
+        assertThat(error.parameters, equalTo(testProblem.parameters))
+        assertThat(error.extra, equalTo(testProblem.extra))
+      }
+    }
+  }
+
+  @Test
+  fun `test unregistered problems decode as generic problems`() {
+
+    val testProblem = TestProblem("Some Extra", URI.create("id:12345"))
+
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(TestProblem.STATUS.statusCode)
+        .addHeader(ContentType, Problem)
+        .setBody(objectMapper.writeValueAsString(testProblem))
+    )
+    server.start()
+    server.use {
+
+      val requestFactory =
+        JdkRequestFactory(
+          URITemplate(server.url("/").toString(), mapOf()),
+        )
+      requestFactory.use {
+
+        val error =
+          assertThrows<DefaultProblem> {
+            runBlocking { requestFactory.result<String>(Method.Get, "/problem") }
+          }
+
+        assertThat(error.type, equalTo(testProblem.type))
+        assertThat(error.title, equalTo(testProblem.title))
+        assertThat(error.status, equalTo(testProblem.status))
+        assertThat(error.detail, equalTo(testProblem.detail))
+        assertThat(error.instance, equalTo(testProblem.instance))
+        assertThat(error.parameters, hasEntry("extra", testProblem.extra))
+      }
+    }
+  }
+
+  @Test
+  fun `test non problem error responses are translated to predefined problems`() {
+
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(400)
+        .addHeader(ContentType, HTML)
+        .setBody("<error>An Error Occurred</error>")
+    )
+    server.start()
+    server.use {
+
+      val requestFactory =
+        JdkRequestFactory(
+          URITemplate(server.url("/").toString(), mapOf()),
+        )
+      requestFactory.use {
+
+        val error =
+          assertThrows<DefaultProblem> {
+            runBlocking { requestFactory.result<String>(Method.Get, "/problem") }
+          }
+
+        assertThat(error.type, equalTo(URI("about:blank")))
+        assertThat(error.title, equalTo("Bad Request"))
+        assertThat(error.status, equalTo(Status.BAD_REQUEST))
+        assertThat(error.detail, nullValue())
+        assertThat(error.instance, nullValue())
+        assertThat(error.parameters, hasEntry("responseText", "<error>An Error Occurred</error>"))
+      }
+    }
+  }
+
+  @Test
+  fun `test problem responses with empty bodies are translated to predefined problems`() {
+
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(400)
+        .addHeader(ContentType, Problem)
+    )
+    server.start()
+    server.use {
+
+      val requestFactory =
+        JdkRequestFactory(
+          URITemplate(server.url("/").toString(), mapOf()),
+        )
+      requestFactory.use {
+
+        val error =
+          assertThrows<DefaultProblem> {
+            runBlocking { requestFactory.result<String>(Method.Get, "/problem") }
+          }
+
+        assertThat(error.type, equalTo(URI("about:blank")))
+        assertThat(error.title, equalTo("Bad Request"))
+        assertThat(error.status, equalTo(Status.BAD_REQUEST))
+        assertThat(error.detail, nullValue())
+        assertThat(error.instance, nullValue())
+        assertThat(error.parameters, anEmptyMap())
+      }
+    }
+  }
+
+  @Test
+  fun `test problem responses fail with SundayError when no JSON decoder`() {
+
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(TestProblem.STATUS.statusCode)
+        .addHeader(ContentType, Problem)
+        .setBody(objectMapper.writeValueAsString(TestProblem("test")))
+    )
+    server.start()
+    server.use {
+
+      val requestFactory =
+        JdkRequestFactory(
+          URITemplate(server.url("/").toString(), mapOf()),
+          mediaTypeDecoders = MediaTypeDecoders.Builder().build()
+        )
+      requestFactory.use {
+
+        val error =
+          assertThrows<SundayError> {
+            runBlocking { requestFactory.result<String>(Method.Get, "/problem") }
+          }
+
+        assertThat(error.reason, equalTo(SundayError.Reason.NoDecoder))
+      }
+    }
+  }
+
+  @Test
+  fun `test problem responses fail when registered JSON decoder is not a structured decoder`() {
+
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(TestProblem.STATUS.statusCode)
+        .addHeader(ContentType, Problem)
+        .setBody(objectMapper.writeValueAsString(TestProblem("test")))
+    )
+    server.start()
+    server.use {
+
+      val requestFactory =
+        JdkRequestFactory(
+          URITemplate(server.url("/").toString(), mapOf()),
+          mediaTypeDecoders = MediaTypeDecoders.Builder()
+            .register(TextDecoder.default, JSON)
+            .build()
+        )
+      requestFactory.use {
+
+        val error =
+          assertThrows<SundayError> {
+            runBlocking { requestFactory.result<String>(Method.Get, "/problem") }
+          }
+
+        assertThat(error.reason, equalTo(SundayError.Reason.NoDecoder))
+      }
+    }
+  }
+
+
+  /**
+   * Event Source/Stream Building
+   */
+
+  @Test
+  fun `builds event sources`() {
+
+    val encodedEvent = "event: hello\nid: 12345\ndata: Hello World!\n\n"
+
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .addHeader(ContentType, EventStream)
+        .setBody(encodedEvent),
+    )
+    server.start()
+    server.use {
+
+      val requestFactory =
+        JdkRequestFactory(
+          URITemplate(server.url("/").toString(), mapOf()),
+        )
+      requestFactory.use {
+
+        runBlocking {
+          withTimeout(5000) {
+            val eventSource = requestFactory.eventSource(Method.Get, "")
+            eventSource.use {
+
+              suspendCancellableCoroutine<Unit> { continuation ->
+                eventSource.onMessage = { _ ->
+                  continuation.resume(Unit)
+                }
+                eventSource.connect()
+              }
+
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  fun `builds event streams`() {
+
+    val encodedEvent = "event: hello\nid: 12345\ndata: {\"target\":\"world\"}\n\n"
+
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .addHeader(ContentType, EventStream)
+        .setBody(encodedEvent),
+    )
+    server.start()
+    server.use {
+
+      val requestFactory =
+        JdkRequestFactory(
+          URITemplate(server.url("/").toString(), mapOf()),
+        )
+      requestFactory.use {
+
+        val result =
+          runBlocking {
+            withTimeout(50000) {
+              val eventStream = requestFactory.eventStream(
+                Method.Get,
+                "",
+                decoder = { decoder, event, _, data, logger ->
+                  when (event) {
+                    "hello" -> decoder.decode<Map<String, Any>>(data, typeOf<Map<String, Any>>())
+                    else -> {
+                      logger.error("unsupported event type")
+                      null
+                    }
+                  }
+                }
+              )
+
+              eventStream.first()
+            }
+          }
+
+        assertThat(result, hasEntry("target", "world"))
+      }
+    }
+  }
+
+  class TestProblem(
+    @JsonProperty("extra") val extra: String,
+    instance: URI? = null
+  ) : AbstractThrowableProblem(
+    URI.create(TYPE),
+    TITLE,
+    STATUS,
+    DETAIL,
+    instance,
+  ) {
+
+    companion object {
+
+      const val TYPE = "http://example.com/test"
+      val STATUS = Status.BAD_REQUEST
+      const val TITLE = "Test Problem"
+      const val DETAIL = "A Test Problem"
+    }
+
+    override fun getCause(): org.zalando.problem.Exceptional? = super.cause
+  }
+
+}

--- a/jdk/src/test/resources/simplelogger.properties
+++ b/jdk/src/test/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.defaultLogLevel=trace

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,7 +29,9 @@ rootProject.name = "sunday"
 include(
   "core",
   "okhttp",
+  "jdk",
 )
 
 project(":core").name = "sunday-core"
 project(":okhttp").name = "sunday-okhttp"
+project(":jdk").name = "sunday-jdk"


### PR DESCRIPTION
Added the `jdk` module that uses JDK 11 HTTP Client to execute HTTP requests. Allows using the Sunday library without requiring the `OkHttp` dependency.

The `jdk` module produces maven artifacts  with the name `sunday-jdk`.