### PR TITLE
Rename ValueResponse to ResultResponse and add RequestFactory overloads

### DIFF
--- a/core/src/main/kotlin/io/outfoxx/sunday/RequestFactory.kt
+++ b/core/src/main/kotlin/io/outfoxx/sunday/RequestFactory.kt
@@ -22,7 +22,7 @@ import io.outfoxx.sunday.http.Method
 import io.outfoxx.sunday.http.Parameters
 import io.outfoxx.sunday.http.Request
 import io.outfoxx.sunday.http.Response
-import io.outfoxx.sunday.http.ValueResponse
+import io.outfoxx.sunday.http.ResultResponse
 import io.outfoxx.sunday.mediatypes.codecs.MediaTypeDecoders
 import io.outfoxx.sunday.mediatypes.codecs.MediaTypeEncoders
 import io.outfoxx.sunday.mediatypes.codecs.TextMediaTypeDecoder
@@ -44,10 +44,12 @@ abstract class RequestFactory : Closeable {
    * Purpose of the request.
    */
   enum class RequestPurpose {
+
     /**
      * Request will be used for normal RPC style calls.
      */
     Normal,
+
     /**
      * Request will be used for Server-Sent Events connections.
      */
@@ -173,10 +175,9 @@ abstract class RequestFactory : Closeable {
 
   /**
    * Create and execute a [request][Request] created from the given request
-   * parameters and return the server's [response][Response] along with a value
-   * decoded based on the response's Content-Type.
+   * parameters and returns a result decoded from the server's response.
    *
-   * @return [ValueResponse] returned from the generated request.
+   * @return Instance of [R] decoded from the HTTP response.
    */
   suspend inline fun <reified B : Any, reified R : Any> result(
     method: Method,
@@ -187,7 +188,7 @@ abstract class RequestFactory : Closeable {
     contentTypes: List<MediaType>? = null,
     acceptTypes: List<MediaType>? = null,
     headers: Parameters? = null,
-  ): ValueResponse<R> = result(
+  ): R = result(
     method,
     pathTemplate,
     pathParameters,
@@ -201,10 +202,9 @@ abstract class RequestFactory : Closeable {
 
   /**
    * Create and execute a [request][Request] created from the given request
-   * parameters and return the server's [response][Response] along with a value
-   * decoded based on the response's Content-Type.
+   * parameters and returns a result decoded from the server's response.
    *
-   * @return [ValueResponse] returned from the generated request.
+   * @return Instance of [R] decoded from the HTTP response.
    */
   suspend inline fun <reified R : Any> result(
     method: Method,
@@ -214,7 +214,7 @@ abstract class RequestFactory : Closeable {
     contentTypes: List<MediaType>? = null,
     acceptTypes: List<MediaType>? = null,
     headers: Parameters? = null,
-  ): ValueResponse<R> = result(
+  ): R = result(
     method,
     pathTemplate,
     pathParameters,
@@ -228,12 +228,11 @@ abstract class RequestFactory : Closeable {
 
   /**
    * Create and execute a [request][Request] created from the given request
-   * parameters and return the server's [response][Response] along with a value
-   * decoded based on the response's Content-Type.
+   * parameters and returns a result decoded from the server's response.
    *
-   * @return [ValueResponse] returned from the generated request.
+   * @return Instance of [R] decoded from the HTTP response.
    */
-  abstract suspend fun <B : Any, R : Any> result(
+  suspend fun <B : Any, R : Any> result(
     method: Method,
     pathTemplate: String,
     pathParameters: Parameters? = null,
@@ -243,7 +242,91 @@ abstract class RequestFactory : Closeable {
     acceptTypes: List<MediaType>? = null,
     headers: Parameters? = null,
     resultType: KType
-  ): ValueResponse<R>
+  ): R = resultResponse<B, R>(
+    method,
+    pathTemplate,
+    pathParameters,
+    queryParameters,
+    body,
+    contentTypes,
+    acceptTypes,
+    headers,
+    resultType,
+  ).result
+
+  /**
+   * Create and execute a [request][Request] created from the given request
+   * parameters and return the server's [response][Response] along with a result
+   * decoded from the server's response.
+   *
+   * @return [ResultResponse] returned from the generated request.
+   */
+  suspend inline fun <reified B : Any, reified R : Any> resultResponse(
+    method: Method,
+    pathTemplate: String,
+    pathParameters: Parameters? = null,
+    queryParameters: Parameters? = null,
+    body: B? = null,
+    contentTypes: List<MediaType>? = null,
+    acceptTypes: List<MediaType>? = null,
+    headers: Parameters? = null,
+  ): ResultResponse<R> = resultResponse(
+    method,
+    pathTemplate,
+    pathParameters,
+    queryParameters,
+    body,
+    contentTypes,
+    acceptTypes,
+    headers,
+    typeOf<R>()
+  )
+
+  /**
+   * Create and execute a [request][Request] created from the given request
+   * parameters and return the server's [response][Response] along with a result
+   * decoded from the server's response.
+   *
+   * @return [ResultResponse] returned from the generated request.
+   */
+  suspend inline fun <reified R : Any> resultResponse(
+    method: Method,
+    pathTemplate: String,
+    pathParameters: Parameters? = null,
+    queryParameters: Parameters? = null,
+    contentTypes: List<MediaType>? = null,
+    acceptTypes: List<MediaType>? = null,
+    headers: Parameters? = null,
+  ): ResultResponse<R> = resultResponse(
+    method,
+    pathTemplate,
+    pathParameters,
+    queryParameters,
+    null as Unit?,
+    contentTypes,
+    acceptTypes,
+    headers,
+    typeOf<R>()
+  )
+
+  /**
+   * Create and execute a [request][Request] created from the given request
+   * parameters and return the server's [response][Response] along with a result
+   * decoded from the server's response.
+   *
+   * @return [ResultResponse] returned from the generated request.
+   */
+  abstract suspend fun <B : Any, R : Any> resultResponse(
+    method: Method,
+    pathTemplate: String,
+    pathParameters: Parameters? = null,
+    queryParameters: Parameters? = null,
+    body: B? = null,
+    contentTypes: List<MediaType>? = null,
+    acceptTypes: List<MediaType>? = null,
+    headers: Parameters? = null,
+    resultType: KType
+  ): ResultResponse<R>
 
   /**
    * Creates an [EventSource] that uses the provided request parameters to supply

--- a/core/src/main/kotlin/io/outfoxx/sunday/http/ResultResponse.kt
+++ b/core/src/main/kotlin/io/outfoxx/sunday/http/ResultResponse.kt
@@ -17,9 +17,9 @@
 package io.outfoxx.sunday.http
 
 /**
- * HTTP response that includes a parsed/decoded value.
+ * HTTP response that includes a parsed/decoded result.
  */
-data class ValueResponse<T : Any>(
-  val value: T,
+data class ResultResponse<T : Any>(
+  val result: T,
   private val response: Response,
 ) : Response by response

--- a/core/src/testFixtures/kotlin/io/outfoxx/sunday/test/GeneratedAPITests.kt
+++ b/core/src/testFixtures/kotlin/io/outfoxx/sunday/test/GeneratedAPITests.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.test
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.outfoxx.sunday.MediaType.Companion.JSON
+import io.outfoxx.sunday.RequestFactory
+import io.outfoxx.sunday.URITemplate
+import io.outfoxx.sunday.http.HeaderNames.ContentLength
+import io.outfoxx.sunday.http.HeaderNames.ContentType
+import io.outfoxx.sunday.http.Method
+import io.outfoxx.sunday.http.ResultResponse
+import io.outfoxx.sunday.mediatypes.codecs.MediaTypeDecoders
+import io.outfoxx.sunday.mediatypes.codecs.MediaTypeEncoders
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasItems
+import org.junit.jupiter.api.Test
+
+abstract class GeneratedAPITests {
+
+  companion object {
+
+    private val objectMapper =
+      ObjectMapper()
+        .findAndRegisterModules()
+  }
+
+  abstract fun createRequestFactory(
+    uriTemplate: URITemplate,
+    encoders: MediaTypeEncoders = MediaTypeEncoders.default,
+    decoders: MediaTypeDecoders = MediaTypeDecoders.default,
+  ): RequestFactory
+
+  class API(private val requestFactory: RequestFactory) {
+
+    data class TestResult(val message: String, val count: Int)
+
+    suspend fun testResult(): TestResult =
+      requestFactory.result(
+        method = Method.Get,
+        pathTemplate = "/test",
+        acceptTypes = listOf(JSON),
+      )
+
+    suspend fun testResultResponse(): ResultResponse<TestResult> =
+      requestFactory.resultResponse(
+        method = Method.Get,
+        pathTemplate = "/test",
+        acceptTypes = listOf(JSON),
+      )
+
+  }
+
+  @Test
+  fun `generated styel API result method`() {
+
+    val testResult = API.TestResult("Test", 10)
+
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .addHeader(ContentType, JSON)
+        .setBody(objectMapper.writeValueAsString(testResult))
+    )
+    server.start()
+    server.use {
+
+      val api = API(createRequestFactory(URITemplate(server.url("/").toString())))
+
+      val result = runBlocking { api.testResult() }
+
+      assertThat(result, equalTo(testResult))
+    }
+  }
+
+  @Test
+  fun `generated styel API result response method`() {
+
+    val testResult = API.TestResult("Test", 10)
+
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .addHeader(ContentType, JSON)
+        .setBody(objectMapper.writeValueAsString(testResult))
+    )
+    server.start()
+    server.use {
+
+      val api = API(createRequestFactory(URITemplate(server.url("/").toString())))
+
+      val result = runBlocking { api.testResultResponse() }
+
+      assertThat(result.result, equalTo(testResult))
+      assertThat(
+        result.headers.map { it.first.lowercase() to it.second.lowercase() },
+        hasItems(ContentType to JSON.value, ContentLength to "29")
+      )
+    }
+  }
+
+}

--- a/core/src/testFixtures/kotlin/io/outfoxx/sunday/test/RequestFactoryTest.kt
+++ b/core/src/testFixtures/kotlin/io/outfoxx/sunday/test/RequestFactoryTest.kt
@@ -336,7 +336,7 @@ abstract class RequestFactoryTest {
 
           val result =
             runBlocking {
-              requestFactory.result<Void, Tester>(
+              requestFactory.resultResponse<Void, Tester>(
                 Method.Get,
                 "",
                 pathParameters = null,
@@ -349,7 +349,7 @@ abstract class RequestFactoryTest {
             }
 
           assertThat(result.headers, hasItem(ContentType to "application/json"))
-          assertThat(result.value, equalTo(tester))
+          assertThat(result.result, equalTo(tester))
         }
     }
   }

--- a/jdk/src/main/kotlin/io/outfoxx/sunday/jdk/JdkRequestFactory.kt
+++ b/jdk/src/main/kotlin/io/outfoxx/sunday/jdk/JdkRequestFactory.kt
@@ -41,7 +41,7 @@ import io.outfoxx.sunday.http.Method
 import io.outfoxx.sunday.http.Parameters
 import io.outfoxx.sunday.http.Request
 import io.outfoxx.sunday.http.Response
-import io.outfoxx.sunday.http.ValueResponse
+import io.outfoxx.sunday.http.ResultResponse
 import io.outfoxx.sunday.http.contentLength
 import io.outfoxx.sunday.http.contentType
 import io.outfoxx.sunday.mediatypes.codecs.MediaTypeDecoders
@@ -221,7 +221,7 @@ class JdkRequestFactory(
     return request.execute()
   }
 
-  override suspend fun <B : Any, R : Any> result(
+  override suspend fun <B : Any, R : Any> resultResponse(
     method: Method,
     pathTemplate: String,
     pathParameters: Parameters?,
@@ -231,7 +231,7 @@ class JdkRequestFactory(
     acceptTypes: List<MediaType>?,
     headers: Parameters?,
     resultType: KType
-  ): ValueResponse<R> {
+  ): ResultResponse<R> {
 
     val response =
       response(
@@ -249,7 +249,7 @@ class JdkRequestFactory(
       throw parseFailure(response)
     }
 
-    return ValueResponse(parseSuccess(response, resultType), response)
+    return ResultResponse(parseSuccess(response, resultType), response)
   }
 
   override fun eventSource(requestSupplier: suspend (Headers) -> Request): EventSource {

--- a/jdk/src/test/kotlin/io/outfoxx/sunday/jdk/JdkGeneratedAPITest.kt
+++ b/jdk/src/test/kotlin/io/outfoxx/sunday/jdk/JdkGeneratedAPITest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.jdk
+
+import io.outfoxx.sunday.RequestFactory
+import io.outfoxx.sunday.URITemplate
+import io.outfoxx.sunday.mediatypes.codecs.MediaTypeDecoders
+import io.outfoxx.sunday.mediatypes.codecs.MediaTypeEncoders
+import io.outfoxx.sunday.test.GeneratedAPITests
+
+class JdkGeneratedAPITest : GeneratedAPITests() {
+
+  override fun createRequestFactory(
+    uriTemplate: URITemplate,
+    encoders: MediaTypeEncoders,
+    decoders: MediaTypeDecoders
+  ): RequestFactory =
+    JdkRequestFactory(
+      uriTemplate,
+      mediaTypeEncoders = encoders,
+      mediaTypeDecoders = decoders,
+    )
+
+}

--- a/okhttp/src/main/kotlin/io/outfoxx/sunday/okhttp/OkHttpRequestFactory.kt
+++ b/okhttp/src/main/kotlin/io/outfoxx/sunday/okhttp/OkHttpRequestFactory.kt
@@ -41,7 +41,7 @@ import io.outfoxx.sunday.http.Method
 import io.outfoxx.sunday.http.Parameters
 import io.outfoxx.sunday.http.Request
 import io.outfoxx.sunday.http.Response
-import io.outfoxx.sunday.http.ValueResponse
+import io.outfoxx.sunday.http.ResultResponse
 import io.outfoxx.sunday.http.contentLength
 import io.outfoxx.sunday.http.contentType
 import io.outfoxx.sunday.mediatypes.codecs.MediaTypeDecoders
@@ -192,7 +192,7 @@ class OkHttpRequestFactory(
     return request.execute()
   }
 
-  override suspend fun <B : Any, R : Any> result(
+  override suspend fun <B : Any, R : Any> resultResponse(
     method: Method,
     pathTemplate: String,
     pathParameters: Parameters?,
@@ -202,7 +202,7 @@ class OkHttpRequestFactory(
     acceptTypes: List<MediaType>?,
     headers: Parameters?,
     resultType: KType
-  ): ValueResponse<R> {
+  ): ResultResponse<R> {
 
     val response =
       response(
@@ -220,7 +220,7 @@ class OkHttpRequestFactory(
       throw parseFailure(response)
     }
 
-    return ValueResponse(parseSuccess(response, resultType), response)
+    return ResultResponse(parseSuccess(response, resultType), response)
   }
 
   override fun eventSource(requestSupplier: suspend (Headers) -> Request): EventSource {

--- a/okhttp/src/test/kotlin/io/outfoxx/sunday/okhttp/OkHttpGeneratedAPITest.kt
+++ b/okhttp/src/test/kotlin/io/outfoxx/sunday/okhttp/OkHttpGeneratedAPITest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.okhttp
+
+import io.outfoxx.sunday.RequestFactory
+import io.outfoxx.sunday.URITemplate
+import io.outfoxx.sunday.mediatypes.codecs.MediaTypeDecoders
+import io.outfoxx.sunday.mediatypes.codecs.MediaTypeEncoders
+import io.outfoxx.sunday.test.GeneratedAPITests
+
+class OkHttpGeneratedAPITest : GeneratedAPITests() {
+
+  override fun createRequestFactory(
+    uriTemplate: URITemplate,
+    encoders: MediaTypeEncoders,
+    decoders: MediaTypeDecoders
+  ): RequestFactory =
+    OkHttpRequestFactory(
+      uriTemplate,
+      mediaTypeEncoders = encoders,
+      mediaTypeDecoders = decoders,
+    )
+
+}


### PR DESCRIPTION
* `ValueResponse` has been renamed to `ResultResponse` to match the result naming in request factory
* `RequestFactory` now has `resultResponse` overloads that return `ResultResponse<R>`
* Added tests that simulate generated APIs