### PR TITLE
Cleanup workflows and automate maven releasing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
 
     - uses: actions/setup-java@v3
       with:
-        java-version: '17'
-        distribution: oracle
+        java-version: '11'
+        distribution: adopt
 
     - name: Build & Test
       uses: burrunan/gradle-cache-action@v1
@@ -31,12 +31,10 @@ jobs:
         job-id: jdk11-build-test
         arguments: check sonar
 
-    - name: Upload Reports
-      uses: actions/upload-artifact@v3
-      if: always()
+    - name: Report Tests
+      uses: dorny/test-reporter@v1
+      if: success() || failure()
       with:
-        name: reports
-        path: |
-          core/build/reports/
-          okhttp/build/reports/
-          jdk/build/reports/
+        name: Tests Results
+        path: "**/build/test-results/*/*.xml"
+        reporter: java-junit

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,8 +21,8 @@ jobs:
 
     - uses: actions/setup-java@v3
       with:
-        java-version: '17'
-        distribution: oracle
+        java-version: '11'
+        distribution: adopt
 
     - name: Build Artifacts & Documentation
       uses: burrunan/gradle-cache-action@v1
@@ -40,11 +40,11 @@ jobs:
         ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
       with:
         job-id: jdk11-build-test
-        arguments: publishRelease -x test
+        arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository githubRelease -x test
         properties: |
           releaseVersion=${{ github.ref_name }}
-          ossrhUsername=${{ secrets.OSSRH_USER }}
-          ossrhPassword=${{ secrets.OSSRH_PASS }}
+          sonatypeUsername=${{ secrets.OSSRH_USER }}
+          sonatypePassword=${{ secrets.OSSRH_PASS }}
           github.token=${{ secrets.GITHUB_TOKEN }}
 
     - name: Publish Documentation

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -21,8 +21,8 @@ jobs:
 
     - uses: actions/setup-java@v3
       with:
-        java-version: '17'
-        distribution: oracle
+        java-version: '11'
+        distribution: adopt
 
     - name: Build Artifacts & Documentation
       uses: burrunan/gradle-cache-action@v1
@@ -34,10 +34,10 @@ jobs:
       uses: burrunan/gradle-cache-action@v1
       with:
         job-id: jdk11-build-test
-        arguments: publishAllPublicationsToMavenCentralRepository
+        arguments: publishToSonatype
         properties: |
-          ossrhUsername=${{ secrets.OSSRH_USER }}
-          ossrhPassword=${{ secrets.OSSRH_PASS }}
+          sonatypeUsername=${{ secrets.OSSRH_USER }}
+          sonatypePassword=${{ secrets.OSSRH_PASS }}
 
     - name: Publish Documentation
       uses: JamesIves/github-pages-deploy-action@v4

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,8 @@ licenserPluginVersion=0.6.1
 kotlinterPluginVersion=3.4.4
 detektPluginVersion=1.22.0
 githubReleasePluginVersion=2.4.1
-sonarqubeVersion=3.5.0.2730
+sonarqubePluginVersion=3.5.0.2730
+nexusPublishPluginVersion=1.1.0
 
 slf4jVersion=2.0.4
 kotlinCoroutinesVersion=1.6.4

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,8 @@ pluginManagement {
   val kotlinterPluginVersion: String by settings
   val detektPluginVersion: String by settings
   val githubReleasePluginVersion: String by settings
-  val sonarqubeVersion: String by settings
+  val sonarqubePluginVersion: String by settings
+  val nexusPublishPluginVersion: String by settings
 
   plugins {
     kotlin("jvm") version kotlinPluginVersion
@@ -21,7 +22,8 @@ pluginManagement {
     id("org.jmailen.kotlinter") version kotlinterPluginVersion
     id("io.gitlab.arturbosch.detekt") version detektPluginVersion
     id("com.github.breadmoirai.github-release") version githubReleasePluginVersion
-    id("org.sonarqube") version sonarqubeVersion
+    id("org.sonarqube") version sonarqubePluginVersion
+    id("io.github.gradle-nexus.publish-plugin") version nexusPublishPluginVersion
   }
 
 }


### PR DESCRIPTION
* Use nexus publishing plugin to automate releasing
* Report test resutls instead of uploading reports
* Fix CI set-java to use `adop` since `oracle` is no longer supported