### PR TITLE
Fix SSE event decode failure handling

### DIFF
--- a/core/src/main/kotlin/io/outfoxx/sunday/RequestFactory.kt
+++ b/core/src/main/kotlin/io/outfoxx/sunday/RequestFactory.kt
@@ -38,6 +38,7 @@ import io.outfoxx.sunday.problems.Problem
 import io.outfoxx.sunday.problems.ProblemFactory
 import io.outfoxx.sunday.problems.ProblemFactory.Descriptor
 import io.outfoxx.sunday.utils.from
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.onFailure
@@ -545,20 +546,28 @@ abstract class RequestFactory : Closeable {
 
         val data = event.data
         if (data != null) {
-          try {
-            val decodedEvent = decoder(jsonDecoder, event.event, event.id, data, logger)
-            if (decodedEvent != null) {
-              trySendBlocking(decodedEvent)
-                .onFailure {
-                  cancel("Event send failed", it)
-                }
-
+          val decodedEvent =
+            try {
+              decoder(jsonDecoder, event.event, event.id, data, logger)
+            } catch (x: CancellationException) {
+              cancel(x)
+              null
+            } catch (x: Exception) {
+              logger.warn(
+                "Skipping undecodable event from EventSource; event={}, id={}",
+                event.event,
+                event.id,
+                SundayError(EventDecodingFailed, cause = x),
+              )
+              null
             }
 
-          } catch (x: Throwable) {
-            cancel("Event decoding failed", SundayError(EventDecodingFailed, cause = x))
+          if (decodedEvent != null) {
+            trySendBlocking(decodedEvent)
+              .onFailure {
+                cancel("Event send failed", it)
+              }
           }
-
         }
 
       }

--- a/core/src/main/kotlin/io/outfoxx/sunday/RequestFactory.kt
+++ b/core/src/main/kotlin/io/outfoxx/sunday/RequestFactory.kt
@@ -552,7 +552,7 @@ abstract class RequestFactory : Closeable {
             } catch (x: CancellationException) {
               cancel(x)
               null
-            } catch (x: Exception) {
+            } catch (x: Throwable) {
               logger.warn(
                 "Skipping undecodable event from EventSource; event={}, id={}",
                 event.event,

--- a/core/src/testFixtures/kotlin/io/outfoxx/sunday/test/RequestFactoryTest.kt
+++ b/core/src/testFixtures/kotlin/io/outfoxx/sunday/test/RequestFactoryTest.kt
@@ -980,7 +980,7 @@ abstract class RequestFactoryTest {
 
             val result =
               withContext(Dispatchers.IO) {
-                withTimeout(50000) {
+                withTimeout(5000) {
                   val eventStream =
                     requestFactory.eventStream(
                       Method.Get,
@@ -1027,7 +1027,7 @@ abstract class RequestFactoryTest {
 
             expectThrows<CancellationException> {
               withContext(Dispatchers.IO) {
-                withTimeout(50000) {
+                withTimeout(5000) {
                   val eventStream =
                     requestFactory.eventStream(
                       Method.Get,

--- a/core/src/testFixtures/kotlin/io/outfoxx/sunday/test/RequestFactoryTest.kt
+++ b/core/src/testFixtures/kotlin/io/outfoxx/sunday/test/RequestFactoryTest.kt
@@ -43,6 +43,7 @@ import io.outfoxx.sunday.mediatypes.codecs.MediaTypeEncoders
 import io.outfoxx.sunday.mediatypes.codecs.TextDecoder
 import io.outfoxx.sunday.mediatypes.codecs.URLQueryParamsEncoder
 import io.outfoxx.sunday.problems.SundayHttpProblem
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -954,6 +955,94 @@ abstract class RequestFactoryTest {
               .containsKey("target")
               .getValue("target")
               .isEqualTo("world")
+          }
+      }
+    }
+
+  @Test
+  fun `event streams skip undecodable events`() =
+    runTest {
+      val encodedEvents =
+        "event: hello\nid: 12345\ndata: {\"target\":}\n\n" +
+          "event: hello\nid: 67890\ndata: {\"target\":\"world\"}\n\n"
+
+      val server = MockWebServer()
+      server.enqueue(
+        MockResponse()
+          .setResponseCode(200)
+          .addHeader(CONTENT_TYPE, EventStream)
+          .setBody(encodedEvents),
+      )
+      server.start()
+      server.use {
+        createRequestFactory(URITemplate(server.url("/").toString()))
+          .use { requestFactory ->
+
+            val result =
+              withContext(Dispatchers.IO) {
+                withTimeout(50000) {
+                  val eventStream =
+                    requestFactory.eventStream(
+                      Method.Get,
+                      "",
+                      decoder = { decoder, event, _, data, logger ->
+                        when (event) {
+                          "hello" -> decoder.decode<Map<String, Any>>(data, typeOf<Map<String, Any>>())
+                          else -> {
+                            logger.error("unsupported event type")
+                            null
+                          }
+                        }
+                      },
+                    )
+
+                  eventStream.first()
+                }
+              }
+
+            expectThat(result)
+              .containsKey("target")
+              .getValue("target")
+              .isEqualTo("world")
+          }
+      }
+    }
+
+  @Test
+  fun `event streams cancel when decoder cancels`() =
+    runTest {
+      val encodedEvent = "event: hello\nid: 12345\ndata: {\"target\":\"world\"}\n\n"
+
+      val server = MockWebServer()
+      server.enqueue(
+        MockResponse()
+          .setResponseCode(200)
+          .addHeader(CONTENT_TYPE, EventStream)
+          .setBody(encodedEvent),
+      )
+      server.start()
+      server.use {
+        createRequestFactory(URITemplate(server.url("/").toString()))
+          .use { requestFactory ->
+
+            expectThrows<CancellationException> {
+              withContext(Dispatchers.IO) {
+                withTimeout(50000) {
+                  val eventStream =
+                    requestFactory.eventStream(
+                      Method.Get,
+                      "",
+                      decoder = { _, _, _, _, _ ->
+                        throw CancellationException("decoder canceled")
+                      },
+                    )
+
+                  eventStream.first()
+                }
+              }
+            }.and {
+              get { message.orEmpty() }.isEqualTo("decoder canceled")
+            }
           }
       }
     }


### PR DESCRIPTION
## Summary

- Skip and warn on undecodable SSE events instead of canceling `RequestFactory.eventStream`.
- Preserve explicit decoder cancellation by canceling the callbackFlow with the original `CancellationException`.
- Add shared request factory tests for malformed event skipping and decoder cancellation.

## Root Cause

`eventStream` handled every decoder exception by calling `cancel("Event decoding failed", ...)`, which turned ordinary decode failures into callbackFlow cancellation. In long-lived consumers this could surface as a swallowed `CancellationException` and leave polling callers waiting for a deadline instead of completing normally.

## Validation

- `./gradlew :sunday-jdk:test --tests io.outfoxx.sunday.jdk.JdkRequestFactoryTest :sunday-okhttp:test --tests io.outfoxx.sunday.okhttp.OkHttpRequestFactoryTest`
- `./gradlew :sunday-core:check`
- `./gradlew check`
