### PR TITLE
Use event transport purpose for SSE requests

### DIFF
--- a/core/src/main/kotlin/io/outfoxx/sunday/Transport.kt
+++ b/core/src/main/kotlin/io/outfoxx/sunday/Transport.kt
@@ -422,6 +422,7 @@ abstract class Transport<out Req : Request> : Closeable {
         contentTypes,
         acceptTypes,
         mergeEventSourceHeaders(headers, eventSourceHeaders),
+        RequestPurpose.Events,
       )
     }
 
@@ -450,6 +451,7 @@ abstract class Transport<out Req : Request> : Closeable {
         contentTypes,
         acceptTypes,
         mergeEventSourceHeaders(headers, eventSourceHeaders),
+        RequestPurpose.Events,
       )
     }
 
@@ -489,6 +491,7 @@ abstract class Transport<out Req : Request> : Closeable {
         contentTypes,
         acceptTypes,
         mergeEventSourceHeaders(headers, eventSourceHeaders),
+        RequestPurpose.Events,
       )
     }
 
@@ -519,6 +522,7 @@ abstract class Transport<out Req : Request> : Closeable {
         contentTypes,
         acceptTypes,
         mergeEventSourceHeaders(headers, eventSourceHeaders),
+        RequestPurpose.Events,
       )
     }
 

--- a/core/src/test/kotlin/io/outfoxx/sunday/OperationTest.kt
+++ b/core/src/test/kotlin/io/outfoxx/sunday/OperationTest.kt
@@ -12,12 +12,20 @@ import io.outfoxx.sunday.problems.Problem
 import io.outfoxx.sunday.problems.ProblemAdapter
 import io.outfoxx.sunday.problems.ProblemFactory
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
 import kotlinx.io.Source
 import org.junit.jupiter.api.Test
+import strikt.api.expectThat
 import strikt.api.expectThrows
+import strikt.assertions.isEqualTo
 import java.net.URI
+import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.reflect.KClass
 
 class OperationTest {
@@ -93,6 +101,54 @@ class OperationTest {
     override fun close() = Unit
   }
 
+  private class CapturingPurposeTransport : Transport<Request>() {
+
+    val purposes = CopyOnWriteArrayList<RequestPurpose>()
+
+    override val registeredProblemTypes: Map<String, KClass<out Problem>> = emptyMap()
+    override val mediaTypeEncoders: MediaTypeEncoders = MediaTypeEncoders.default
+    override val mediaTypeDecoders: MediaTypeDecoders = MediaTypeDecoders.default
+    override val pathEncoders: Map<KClass<*>, PathEncoder> = PathEncoders.default
+    override val problemFactory: ProblemFactory = ThrowingProblemFactory
+
+    override fun registerProblem(
+      typeId: String,
+      problemType: KClass<out Problem>,
+    ) = Unit
+
+    override suspend fun <B : Any> transportRequest(
+      method: Method,
+      pathTemplate: String,
+      pathParameters: Parameters?,
+      queryParameters: Parameters?,
+      body: B?,
+      contentTypes: List<MediaType>?,
+      acceptTypes: List<MediaType>?,
+      headers: Parameters?,
+      purpose: RequestPurpose,
+    ): Request {
+      purposes += purpose
+      return TestRequest(method, URI.create("http://example.com"), emptyList())
+    }
+
+    override suspend fun transportResponse(request: Request): Response = error("unused")
+
+    override fun eventSource(requestSupplier: suspend (Headers) -> Request): EventSource =
+      EventSource(requestSupplier, problemFactory, eventTimeout = null)
+
+    override fun close(cancelOutstandingRequests: Boolean) = Unit
+
+    override fun close() = Unit
+
+    suspend fun awaitPurpose() {
+      withTimeout(1_000) {
+        while (purposes.isEmpty()) {
+          yield()
+        }
+      }
+    }
+  }
+
   @Test
   fun `nullable operations rethrow cancellation without nullify matching`() =
     runTest {
@@ -108,5 +164,70 @@ class OperationTest {
       expectThrows<CancellationException> {
         operation.executeOrNull()
       }
+    }
+
+  @Test
+  fun `event sources build event requests`() =
+    runTest {
+      val transport = CapturingPurposeTransport()
+      val eventSource = transport.eventSource(Method.Get, "/events")
+
+      eventSource.connect()
+      eventSource.close()
+
+      expectThat(transport.purposes.toList()).isEqualTo(listOf(Transport.RequestPurpose.Events))
+    }
+
+  @Test
+  fun `event sources with bodies build event requests`() =
+    runTest {
+      val transport = CapturingPurposeTransport()
+      val eventSource = transport.eventSource<Unit>(Method.Get, "/events", body = null)
+
+      eventSource.connect()
+      eventSource.close()
+
+      expectThat(transport.purposes.toList()).isEqualTo(listOf(Transport.RequestPurpose.Events))
+    }
+
+  @Test
+  fun `event streams build event requests`() =
+    runTest {
+      val transport = CapturingPurposeTransport()
+      val job =
+        launch {
+          transport
+            .eventStream<Unit>(
+              Method.Get,
+              "/events",
+              decoder = { _, _, _, _, _ -> Unit },
+            ).collect()
+        }
+
+      transport.awaitPurpose()
+      job.cancelAndJoin()
+
+      expectThat(transport.purposes.toList()).isEqualTo(listOf(Transport.RequestPurpose.Events))
+    }
+
+  @Test
+  fun `event streams with bodies build event requests`() =
+    runTest {
+      val transport = CapturingPurposeTransport()
+      val job =
+        launch {
+          transport
+            .eventStream<Unit, Unit>(
+              Method.Get,
+              "/events",
+              body = null,
+              decoder = { _, _, _, _, _ -> Unit },
+            ).collect()
+        }
+
+      transport.awaitPurpose()
+      job.cancelAndJoin()
+
+      expectThat(transport.purposes.toList()).isEqualTo(listOf(Transport.RequestPurpose.Events))
     }
 }


### PR DESCRIPTION
## Summary
- pass RequestPurpose.Events when building EventSource and eventStream requests
- add focused tests for event source/stream wrappers with and without request bodies

## Verification
- ./gradlew :sunday-core:test --tests io.outfoxx.sunday.OperationTest --rerun-tasks
- ./gradlew :sunday-core:check --rerun-tasks
- ./gradlew check --rerun-tasks