### PR TITLE
Add Kotlin streaming request bodies

### DIFF
--- a/core/src/main/kotlin/io/outfoxx/sunday/Operation.kt
+++ b/core/src/main/kotlin/io/outfoxx/sunday/Operation.kt
@@ -112,6 +112,11 @@ class Operation<B : Any, R : Any, Req : Request>(
 }
 
 /**
+ * A generated operation with a streaming request body.
+ */
+typealias StreamingOperation<R, Req> = Operation<StreamingBody, R, Req>
+
+/**
  * A generated operation that can execute select problems as null responses.
  */
 class NullableOperation<B : Any, R : Any, Req : Request>(

--- a/core/src/main/kotlin/io/outfoxx/sunday/StreamingBody.kt
+++ b/core/src/main/kotlin/io/outfoxx/sunday/StreamingBody.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday
+
+import kotlinx.io.Source
+import kotlinx.io.asSource
+import kotlinx.io.buffered
+import java.io.InputStream
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * A replayable streaming request body.
+ */
+class StreamingBody private constructor(
+  val contentLength: Long?,
+  private val sourceFactory: () -> Source,
+) {
+
+  init {
+    require(contentLength == null || contentLength >= 0) {
+      "contentLength must be greater than or equal to zero"
+    }
+  }
+
+  /**
+   * Opens a fresh body source.
+   */
+  fun openSource(): Source = sourceFactory()
+
+  companion object {
+
+    /**
+     * Creates a streaming body from a replayable source factory.
+     */
+    fun source(
+      contentLength: Long? = null,
+      sourceFactory: () -> Source,
+    ): StreamingBody = StreamingBody(contentLength, sourceFactory)
+
+    /**
+     * Creates a streaming body from a replayable input stream factory.
+     */
+    fun inputStream(
+      contentLength: Long? = null,
+      inputStreamFactory: () -> InputStream,
+    ): StreamingBody =
+      source(contentLength) {
+        inputStreamFactory()
+          .asSource()
+          .buffered()
+      }
+
+    /**
+     * Creates a streaming body from a file.
+     */
+    fun file(path: Path): StreamingBody =
+      inputStream(Files.size(path)) {
+        Files.newInputStream(path)
+      }
+  }
+}

--- a/core/src/test/kotlin/io/outfoxx/sunday/StreamingBodyTest.kt
+++ b/core/src/test/kotlin/io/outfoxx/sunday/StreamingBodyTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday
+
+import kotlinx.io.readByteArray
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import strikt.api.expectThat
+import strikt.api.expectThrows
+import strikt.assertions.isEqualTo
+import java.nio.file.Files
+import java.nio.file.Path
+
+class StreamingBodyTest {
+
+  @Test
+  fun `file bodies report length and open replayable sources`(
+    @TempDir tempDir: Path,
+  ) {
+    val path = tempDir.resolve("body.bin")
+    Files.write(path, byteArrayOf(1, 2, 3))
+
+    val body = StreamingBody.file(path)
+
+    expectThat(body.contentLength).isEqualTo(3)
+    expectThat(body.openSource().readByteArray()).isEqualTo(byteArrayOf(1, 2, 3))
+    expectThat(body.openSource().readByteArray()).isEqualTo(byteArrayOf(1, 2, 3))
+  }
+
+  @Test
+  fun `body length must be non-negative`() {
+    expectThrows<IllegalArgumentException> {
+      StreamingBody.source(contentLength = -1) {
+        error("should not open")
+      }
+    }
+  }
+}

--- a/jdk/src/main/kotlin/io/outfoxx/sunday/jdk/JdkTransport.kt
+++ b/jdk/src/main/kotlin/io/outfoxx/sunday/jdk/JdkTransport.kt
@@ -50,7 +50,9 @@ import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpRequest.BodyPublishers
+import java.nio.ByteBuffer
 import java.time.Duration
+import java.util.concurrent.Flow
 import kotlin.reflect.KClass
 
 /**
@@ -151,7 +153,7 @@ class JdkTransport(
       streamingBody?.let {
         contentType ?: throw SundayError(NoSupportedContentTypes)
 
-        BodyPublishers.ofInputStream { streamingBody.openSource().asInputStream() }
+        streamingBody.bodyPublisher()
       } ?: body?.let {
         contentType ?: throw SundayError(NoSupportedContentTypes)
 
@@ -234,5 +236,24 @@ class JdkTransport(
 
   override fun close(cancelOutstandingRequests: Boolean) {
     // TODO track outstanding requests and implement appropriately
+  }
+
+  private fun StreamingBody.bodyPublisher(): HttpRequest.BodyPublisher {
+    val publisher = BodyPublishers.ofInputStream { openSource().asInputStream() }
+    return contentLength?.let { contentLength ->
+      ContentLengthBodyPublisher(publisher, contentLength)
+    } ?: publisher
+  }
+
+  private class ContentLengthBodyPublisher(
+    private val delegate: HttpRequest.BodyPublisher,
+    private val contentLength: Long,
+  ) : HttpRequest.BodyPublisher {
+
+    override fun contentLength(): Long = contentLength
+
+    override fun subscribe(subscriber: Flow.Subscriber<in ByteBuffer>) {
+      delegate.subscribe(subscriber)
+    }
   }
 }

--- a/jdk/src/main/kotlin/io/outfoxx/sunday/jdk/JdkTransport.kt
+++ b/jdk/src/main/kotlin/io/outfoxx/sunday/jdk/JdkTransport.kt
@@ -21,6 +21,7 @@ import io.outfoxx.sunday.MediaType
 import io.outfoxx.sunday.MediaType.Companion.WWWFormUrlEncoded
 import io.outfoxx.sunday.PathEncoder
 import io.outfoxx.sunday.PathEncoders
+import io.outfoxx.sunday.StreamingBody
 import io.outfoxx.sunday.SundayError
 import io.outfoxx.sunday.SundayError.Reason.InvalidBaseUri
 import io.outfoxx.sunday.SundayError.Reason.NoDecoder
@@ -135,13 +136,23 @@ class JdkTransport(
       requestBuilder.header(ACCEPT, accept)
     }
 
-    val contentType = contentTypes?.firstOrNull(mediaTypeEncoders::supports)
+    val streamingBody = body as? StreamingBody
+    val contentType =
+      if (streamingBody != null) {
+        contentTypes?.firstOrNull()
+      } else {
+        contentTypes?.firstOrNull(mediaTypeEncoders::supports)
+      }
 
     // Add a `Content-Type` header (even if the body is null, to match any expected server requirements)
     contentType?.let { requestBuilder.header(CONTENT_TYPE, contentType.toString()) }
 
     var requestBodyPublisher =
-      body?.let {
+      streamingBody?.let {
+        contentType ?: throw SundayError(NoSupportedContentTypes)
+
+        BodyPublishers.ofInputStream { streamingBody.openSource().asInputStream() }
+      } ?: body?.let {
         contentType ?: throw SundayError(NoSupportedContentTypes)
 
         val mediaTypeEncoder =

--- a/jdk/src/test/kotlin/io/outfoxx/sunday/jdk/JdkRequestBodyTest.kt
+++ b/jdk/src/test/kotlin/io/outfoxx/sunday/jdk/JdkRequestBodyTest.kt
@@ -17,11 +17,16 @@
 package io.outfoxx.sunday.jdk
 
 import io.outfoxx.sunday.MediaType
+import io.outfoxx.sunday.StreamingBody
 import io.outfoxx.sunday.URITemplate
+import io.outfoxx.sunday.http.HeaderNames.CONTENT_TYPE
 import io.outfoxx.sunday.http.Method
+import io.outfoxx.sunday.http.getFirstOrNull
 import io.outfoxx.sunday.problems.SundayHttpProblem
 import kotlinx.coroutines.test.runTest
+import kotlinx.io.Buffer
 import kotlinx.io.readByteArray
+import kotlinx.io.write
 import org.junit.jupiter.api.Test
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
@@ -44,5 +49,31 @@ class JdkRequestBodyTest {
       val body = request.body()
 
       expectThat(body?.readByteArray()).isEqualTo("""{"a":1}""".encodeToByteArray())
+    }
+
+  @Test
+  fun `streaming request bodies are opened lazily and replayed`() =
+    runTest {
+      val factory = JdkTransport(URITemplate("http://example.com"), SundayHttpProblem.Factory)
+      var opened = 0
+      val requestBody =
+        StreamingBody.source(contentLength = 3) {
+          opened += 1
+          Buffer().apply { write(byteArrayOf(1, 2, 3)) }
+        }
+
+      val request =
+        factory.transportRequest(
+          Method.Put,
+          "/body",
+          body = requestBody,
+          contentTypes = listOf(MediaType.from("image/png")),
+        )
+
+      expectThat(opened).isEqualTo(0)
+      expectThat(request.headers.getFirstOrNull(CONTENT_TYPE)).isEqualTo("image/png")
+      expectThat(request.body()?.readByteArray()).isEqualTo(byteArrayOf(1, 2, 3))
+      expectThat(request.body()?.readByteArray()).isEqualTo(byteArrayOf(1, 2, 3))
+      expectThat(opened).isEqualTo(2)
     }
 }

--- a/jdk/src/test/kotlin/io/outfoxx/sunday/jdk/JdkRequestBodyTest.kt
+++ b/jdk/src/test/kotlin/io/outfoxx/sunday/jdk/JdkRequestBodyTest.kt
@@ -54,7 +54,16 @@ class JdkRequestBodyTest {
   @Test
   fun `streaming request bodies are opened lazily and replayed`() =
     runTest {
-      val factory = JdkTransport(URITemplate("http://example.com"), SundayHttpProblem.Factory)
+      var contentLength: Long? = null
+      val factory =
+        JdkTransport(
+          URITemplate("http://example.com"),
+          SundayHttpProblem.Factory,
+          adapter = { request ->
+            contentLength = request.bodyPublisher().orElseThrow().contentLength()
+            request
+          },
+        )
       var opened = 0
       val requestBody =
         StreamingBody.source(contentLength = 3) {
@@ -71,6 +80,7 @@ class JdkRequestBodyTest {
         )
 
       expectThat(opened).isEqualTo(0)
+      expectThat(contentLength).isEqualTo(3)
       expectThat(request.headers.getFirstOrNull(CONTENT_TYPE)).isEqualTo("image/png")
       expectThat(request.body()?.readByteArray()).isEqualTo(byteArrayOf(1, 2, 3))
       expectThat(request.body()?.readByteArray()).isEqualTo(byteArrayOf(1, 2, 3))

--- a/okhttp/src/main/kotlin/io/outfoxx/sunday/okhttp/OkHttpTransport.kt
+++ b/okhttp/src/main/kotlin/io/outfoxx/sunday/okhttp/OkHttpTransport.kt
@@ -218,8 +218,8 @@ class OkHttpTransport(
 
     override fun writeTo(sink: BufferedSink) {
       body.openSource().use { source ->
+        val buffer = Buffer()
         while (true) {
-          val buffer = Buffer()
           val bytesRead = source.readAtMostTo(buffer, READ_SIZE)
           if (bytesRead == EOF) {
             break

--- a/okhttp/src/main/kotlin/io/outfoxx/sunday/okhttp/OkHttpTransport.kt
+++ b/okhttp/src/main/kotlin/io/outfoxx/sunday/okhttp/OkHttpTransport.kt
@@ -21,6 +21,7 @@ import io.outfoxx.sunday.MediaType
 import io.outfoxx.sunday.MediaType.Companion.WWWFormUrlEncoded
 import io.outfoxx.sunday.PathEncoder
 import io.outfoxx.sunday.PathEncoders
+import io.outfoxx.sunday.StreamingBody
 import io.outfoxx.sunday.SundayError
 import io.outfoxx.sunday.SundayError.Reason.InvalidBaseUri
 import io.outfoxx.sunday.SundayError.Reason.NoDecoder
@@ -41,11 +42,15 @@ import io.outfoxx.sunday.mediatypes.codecs.MediaTypeEncoders
 import io.outfoxx.sunday.mediatypes.codecs.URLQueryParamsEncoder
 import io.outfoxx.sunday.problems.Problem
 import io.outfoxx.sunday.problems.ProblemFactory
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
 import kotlinx.io.readByteString
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
+import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
+import okio.BufferedSink
 import org.slf4j.LoggerFactory
 import java.io.Closeable
 import kotlin.reflect.KClass
@@ -64,6 +69,8 @@ class OkHttpTransport(
   companion object {
 
     private val logger = LoggerFactory.getLogger(OkHttpTransport::class.java)
+    private const val EOF = -1L
+    private const val READ_SIZE = 8192L
   }
 
   override val registeredProblemTypes: Map<String, KClass<out Problem>>
@@ -132,13 +139,23 @@ class OkHttpTransport(
       requestBuilder.header(ACCEPT, accept)
     }
 
-    val contentType = contentTypes?.firstOrNull(mediaTypeEncoders::supports)
+    val streamingBody = body as? StreamingBody
+    val contentType =
+      if (streamingBody != null) {
+        contentTypes?.firstOrNull()
+      } else {
+        contentTypes?.firstOrNull(mediaTypeEncoders::supports)
+      }
 
     // Add a `Content-Type` header (even if the body is null, to match any expected server requirements)
     contentType?.let { requestBuilder.addHeader(CONTENT_TYPE, contentType.toString()) }
 
     var requestBody =
-      body?.let {
+      streamingBody?.let {
+        contentType ?: throw SundayError(NoSupportedContentTypes)
+
+        StreamingRequestBody(streamingBody, contentType.value.toMediaType())
+      } ?: body?.let {
         contentType ?: throw SundayError(NoSupportedContentTypes)
 
         val mediaTypeEncoder =
@@ -187,6 +204,29 @@ class OkHttpTransport(
     if (cancelOutstandingRequests) {
       httpClient.dispatcher.cancelAll()
       eventHttpClient.dispatcher.cancelAll()
+    }
+  }
+
+  private class StreamingRequestBody(
+    private val body: StreamingBody,
+    private val contentType: okhttp3.MediaType,
+  ) : RequestBody() {
+
+    override fun contentType(): okhttp3.MediaType = contentType
+
+    override fun contentLength(): Long = body.contentLength ?: -1L
+
+    override fun writeTo(sink: BufferedSink) {
+      body.openSource().use { source ->
+        while (true) {
+          val buffer = Buffer()
+          val bytesRead = source.readAtMostTo(buffer, READ_SIZE)
+          if (bytesRead == EOF) {
+            break
+          }
+          sink.write(buffer.readByteArray())
+        }
+      }
     }
   }
 }

--- a/okhttp/src/test/kotlin/io/outfoxx/sunday/okhttp/OkHttpRequestBodyTest.kt
+++ b/okhttp/src/test/kotlin/io/outfoxx/sunday/okhttp/OkHttpRequestBodyTest.kt
@@ -17,11 +17,16 @@
 package io.outfoxx.sunday.okhttp
 
 import io.outfoxx.sunday.MediaType
+import io.outfoxx.sunday.StreamingBody
 import io.outfoxx.sunday.URITemplate
+import io.outfoxx.sunday.http.HeaderNames.CONTENT_TYPE
 import io.outfoxx.sunday.http.Method
+import io.outfoxx.sunday.http.getFirstOrNull
 import io.outfoxx.sunday.problems.SundayHttpProblem
 import kotlinx.coroutines.test.runTest
+import kotlinx.io.Buffer
 import kotlinx.io.readByteArray
+import kotlinx.io.write
 import org.junit.jupiter.api.Test
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
@@ -44,5 +49,31 @@ class OkHttpRequestBodyTest {
       val body = request.body()
 
       expectThat(body?.readByteArray()).isEqualTo("""{"a":1}""".encodeToByteArray())
+    }
+
+  @Test
+  fun `streaming request bodies are opened lazily and replayed`() =
+    runTest {
+      val factory = OkHttpTransport(URITemplate("http://example.com"), SundayHttpProblem.Factory)
+      var opened = 0
+      val requestBody =
+        StreamingBody.source(contentLength = 3) {
+          opened += 1
+          Buffer().apply { write(byteArrayOf(1, 2, 3)) }
+        }
+
+      val request =
+        factory.transportRequest(
+          Method.Put,
+          "/body",
+          body = requestBody,
+          contentTypes = listOf(MediaType.from("image/png")),
+        )
+
+      expectThat(opened).isEqualTo(0)
+      expectThat(request.headers.getFirstOrNull(CONTENT_TYPE)).isEqualTo("image/png")
+      expectThat(request.body()?.readByteArray()).isEqualTo(byteArrayOf(1, 2, 3))
+      expectThat(request.body()?.readByteArray()).isEqualTo(byteArrayOf(1, 2, 3))
+      expectThat(opened).isEqualTo(2)
     }
 }


### PR DESCRIPTION
Summary: Add replayable StreamingBody support and wire JDK/OkHttp transports for streaming request uploads. Validation: ./gradlew :sunday-core:test :sunday-jdk:test :sunday-okhttp:test --tests io.outfoxx.sunday.StreamingBodyTest --tests io.outfoxx.sunday.jdk.JdkRequestBodyTest --tests io.outfoxx.sunday.okhttp.OkHttpRequestBodyTest --rerun-tasks; ./gradlew ktlintCheck --rerun-tasks