### PR TITLE
Regenerate release publication signatures

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -26,6 +26,8 @@ jobs:
 
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v5.0.0
+      with:
+        cache-disabled: true
 
     - name: Build Artifacts & Documentation
       run: >-
@@ -40,6 +42,8 @@ jobs:
         -PreleaseVersion=${{ github.ref_name }}
         publishToMavenCentral
         -x test
+        --rerun-tasks
+        --no-build-cache
       env:
         ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_CENTRAL_USERNAME }}
         ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_CENTRAL_PASSWORD }}


### PR DESCRIPTION
Summary: Disable Gradle cache use in release publishing and force Maven publication tasks to rerun so signed artifacts are generated fresh. Validation: inspected the failed beta.2 release logs and verified the workflow YAML diff.