### PR TITLE
Add Quarkus JAX-RS streaming request reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Artifacts
 - `sunday-core`: Core types and client abstractions.
 - `sunday-okhttp`: OkHttp-based transport implementation.
 - `sunday-jdk`: JDK `HttpClient`-based transport implementation.
+- `sunday-jaxrs-quarkus`: Quarkus REST/JAX-RS support utilities.
 - `sunday-problem`: Default RFC7807 problem type (`SundayHttpProblem`) and adapters.
 - `sunday-problem-quarkus`: Quarkus `HttpProblem` integration.
 - `sunday-problem-zalando`: Zalando `problem` integration.
@@ -35,6 +36,7 @@ Artifacts
 ```kotlin
 implementation("io.outfoxx.sunday:sunday-core:$version")
 implementation("io.outfoxx.sunday:sunday-okhttp:$version") // or sunday-jdk
+implementation("io.outfoxx.sunday:sunday-jaxrs-quarkus:$version") // Quarkus REST/JAX-RS server support
 implementation("io.outfoxx.sunday:sunday-problem:$version") // or sunday-problem-quarkus / sunday-problem-zalando
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ val releaseVersion: String by project
 group = "io.outfoxx.sunday"
 version = releaseVersion
 
-val moduleNames = listOf("core", "jdk", "okhttp", "problem", "problem-quarkus", "problem-zalando")
+val moduleNames = listOf("core", "jdk", "okhttp", "jaxrs-quarkus", "problem", "problem-quarkus", "problem-zalando")
 
 //
 // ANALYSIS

--- a/code-coverage/build.gradle.kts
+++ b/code-coverage/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
   kover(project(":sunday-core"))
   kover(project(":sunday-jdk"))
   kover(project(":sunday-okhttp"))
+  kover(project(":sunday-jaxrs-quarkus"))
   kover(project(":sunday-problem"))
   kover(project(":sunday-problem-quarkus"))
   kover(project(":sunday-problem-zalando"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,8 @@ zalando-problem = "0.27.1"
 checker-qual = "3.53.0"
 qv-problem = "3.21.0"
 jakarta-rest-api = "3.1.0"
+quarkus = "3.25.2"
+mutiny-vertx = "3.16.0"
 
 slf4j = "2.0.17"
 kotlinCoroutines = "1.10.2"
@@ -51,6 +53,13 @@ zalando-problem-jackson = { module = "org.zalando:jackson-datatype-problem", ver
 checker-qual = { module = "org.checkerframework:checker-qual", version.ref = "checker-qual" }
 
 qv-problem = { module = "io.quarkiverse.resteasy-problem:quarkus-resteasy-problem", version.ref = "qv-problem" }
+quarkus-bom = { module = "io.quarkus.platform:quarkus-bom", version.ref = "quarkus" }
+quarkus-rest = { module = "io.quarkus:quarkus-rest" }
+quarkus-junit5 = { module = "io.quarkus:quarkus-junit5" }
+mutiny = { module = "io.smallrye.reactive:mutiny" }
+mutiny-vertx-core = { module = "io.smallrye.reactive:smallrye-mutiny-vertx-core", version.ref = "mutiny-vertx" }
+resteasy-reactive = { module = "io.quarkus.resteasy.reactive:resteasy-reactive" }
+resteasy-reactive-vertx = { module = "io.quarkus.resteasy.reactive:resteasy-reactive-vertx" }
 
 uri-template = { module = "com.github.hal4j:uritemplate", version.ref = "uriTemplate" }
 
@@ -80,3 +89,4 @@ dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 github-release = { id = "com.github.breadmoirai.github-release", version.ref = "githubRelease" }
 sonarqube = { id = "org.sonarqube", version.ref = "sonarqube" }
+quarkus = { id = "io.quarkus", version.ref = "quarkus" }

--- a/jaxrs-quarkus/build.gradle.kts
+++ b/jaxrs-quarkus/build.gradle.kts
@@ -23,5 +23,4 @@ dependencies {
   implementation(libs.resteasy.reactive.vertx)
 
   testImplementation(libs.quarkus.junit5)
-  testImplementation(libs.quarkus.rest)
 }

--- a/jaxrs-quarkus/build.gradle.kts
+++ b/jaxrs-quarkus/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+  id("library.conventions")
+  alias(libs.plugins.quarkus)
+}
+
+tasks.named("compileKotlin") {
+  dependsOn("compileQuarkusGeneratedSourcesJava")
+}
+
+tasks.matching { it.name == "runKtlintCheckOverMainSourceSet" }.configureEach {
+  dependsOn("compileQuarkusGeneratedSourcesJava")
+}
+
+dependencies {
+
+  implementation(enforcedPlatform(libs.quarkus.bom))
+
+  api(libs.mutiny)
+  api(libs.mutiny.vertx.core)
+
+  implementation(libs.quarkus.rest)
+  implementation(libs.resteasy.reactive)
+  implementation(libs.resteasy.reactive.vertx)
+
+  testImplementation(libs.quarkus.junit5)
+  testImplementation(libs.quarkus.rest)
+}

--- a/jaxrs-quarkus/src/main/kotlin/io/outfoxx/sunday/jaxrs/quarkus/StreamingBufferMessageBodyReader.kt
+++ b/jaxrs-quarkus/src/main/kotlin/io/outfoxx/sunday/jaxrs/quarkus/StreamingBufferMessageBodyReader.kt
@@ -105,10 +105,35 @@ class StreamingBufferMessageBodyReader : ServerMessageBodyReader<Multi<Buffer>> 
     private val inputStream: InputStream,
   ) : Flow.Publisher<Buffer> {
 
+    private var subscribed = false
+
     override fun subscribe(subscriber: Flow.Subscriber<in Buffer>) {
+      val accepted =
+        synchronized(this) {
+          if (subscribed) {
+            false
+          } else {
+            subscribed = true
+            true
+          }
+        }
+
+      if (!accepted) {
+        subscriber.onSubscribe(RejectedSubscription)
+        subscriber.onError(IllegalStateException("Streaming request body can only be consumed once"))
+        return
+      }
+
       val subscription = StreamingBufferSubscription(inputStream, subscriber)
       subscriber.onSubscribe(subscription)
     }
+  }
+
+  private object RejectedSubscription : Flow.Subscription {
+
+    override fun request(n: Long) = Unit
+
+    override fun cancel() = Unit
   }
 
   private class StreamingBufferSubscription(

--- a/jaxrs-quarkus/src/main/kotlin/io/outfoxx/sunday/jaxrs/quarkus/StreamingBufferMessageBodyReader.kt
+++ b/jaxrs-quarkus/src/main/kotlin/io/outfoxx/sunday/jaxrs/quarkus/StreamingBufferMessageBodyReader.kt
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.jaxrs.quarkus
+
+import io.smallrye.mutiny.Multi
+import io.smallrye.mutiny.infrastructure.Infrastructure
+import io.vertx.mutiny.core.buffer.Buffer
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.InternalServerErrorException
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.MultivaluedMap
+import jakarta.ws.rs.ext.Provider
+import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo
+import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyReader
+import org.jboss.resteasy.reactive.server.spi.ServerRequestContext
+import org.jboss.resteasy.reactive.server.vertx.VertxResteasyReactiveRequestContext
+import java.io.IOException
+import java.io.InputStream
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+import java.util.Arrays
+import java.util.concurrent.Flow
+
+/**
+ * Reads a Quarkus request body as a demand-driven stream of Vert.x buffers.
+ */
+@Provider
+@Consumes("*/*")
+class StreamingBufferMessageBodyReader : ServerMessageBodyReader<Multi<Buffer>> {
+
+  override fun isReadable(
+    type: Class<*>,
+    genericType: Type,
+    annotations: Array<out Annotation>,
+    mediaType: MediaType,
+  ): Boolean = isStreamingBufferMulti(type, genericType)
+
+  override fun isReadable(
+    type: Class<*>,
+    genericType: Type,
+    lazyMethod: ResteasyReactiveResourceInfo,
+    mediaType: MediaType,
+  ): Boolean = isStreamingBufferMulti(type, genericType)
+
+  override fun readFrom(
+    type: Class<Multi<Buffer>>,
+    genericType: Type,
+    annotations: Array<out Annotation>,
+    mediaType: MediaType,
+    httpHeaders: MultivaluedMap<String, String>,
+    entityStream: InputStream,
+  ): Multi<Buffer> =
+    throw UnsupportedOperationException(
+      "Streaming request bodies require Quarkus RESTEasy Reactive server request context",
+    )
+
+  override fun readFrom(
+    type: Class<Multi<Buffer>>,
+    genericType: Type,
+    mediaType: MediaType,
+    context: ServerRequestContext,
+  ): Multi<Buffer> {
+    if (context !is VertxResteasyReactiveRequestContext) {
+      throw InternalServerErrorException(
+        "Streaming request bodies require Vert.x-backed Quarkus RESTEasy Reactive request context",
+      )
+    }
+
+    return Multi
+      .createFrom()
+      .publisher(StreamingBufferPublisher(context.inputStream))
+  }
+
+  private fun isStreamingBufferMulti(
+    type: Class<*>,
+    genericType: Type,
+  ): Boolean {
+    if (type != Multi::class.java) {
+      return false
+    }
+
+    val parameterizedType = genericType as? ParameterizedType ?: return false
+    if (parameterizedType.rawType != Multi::class.java) {
+      return false
+    }
+
+    return parameterizedType.actualTypeArguments.singleOrNull() == Buffer::class.java
+  }
+
+  private class StreamingBufferPublisher(
+    private val inputStream: InputStream,
+  ) : Flow.Publisher<Buffer> {
+
+    override fun subscribe(subscriber: Flow.Subscriber<in Buffer>) {
+      val subscription = StreamingBufferSubscription(inputStream, subscriber)
+      subscriber.onSubscribe(subscription)
+    }
+  }
+
+  private class StreamingBufferSubscription(
+    private val inputStream: InputStream,
+    private val subscriber: Flow.Subscriber<in Buffer>,
+  ) : Flow.Subscription {
+
+    private var demand: Long = 0
+    private var reading = false
+    private var terminated = false
+
+    override fun request(n: Long) {
+      if (n <= 0) {
+        fail(IllegalArgumentException("Reactive stream demand must be positive"))
+        return
+      }
+
+      synchronized(this) {
+        demand = addDemand(demand, n)
+      }
+
+      readIfNeeded()
+    }
+
+    override fun cancel() {
+      cleanup()
+    }
+
+    private fun readIfNeeded() {
+      val shouldRead =
+        synchronized(this) {
+          if (terminated || reading || demand <= 0) {
+            false
+          } else {
+            reading = true
+            true
+          }
+        }
+
+      if (shouldRead) {
+        Infrastructure.getDefaultExecutor().execute(::readUntilDemandSatisfied)
+      }
+    }
+
+    private fun readUntilDemandSatisfied() {
+      val bytes = ByteArray(CHUNK_SIZE)
+
+      try {
+        while (tryReserveDemand()) {
+          val count = inputStream.read(bytes)
+          if (count < 0) {
+            complete()
+            return
+          }
+          if (count > 0) {
+            subscriber.onNext(Buffer.buffer(Arrays.copyOf(bytes, count)))
+          }
+        }
+      } catch (failure: Throwable) {
+        fail(failure)
+        return
+      }
+
+      synchronized(this) {
+        reading = false
+      }
+
+      readIfNeeded()
+    }
+
+    private fun tryReserveDemand(): Boolean =
+      synchronized(this) {
+        if (terminated || demand <= 0) {
+          false
+        } else {
+          if (demand != Long.MAX_VALUE) {
+            demand -= 1
+          }
+          true
+        }
+      }
+
+    private fun complete() {
+      if (cleanup()) {
+        subscriber.onComplete()
+      }
+    }
+
+    private fun fail(failure: Throwable) {
+      if (cleanup()) {
+        subscriber.onError(failure)
+      }
+    }
+
+    private fun cleanup(): Boolean {
+      val shouldSignal =
+        synchronized(this) {
+          if (terminated) {
+            false
+          } else {
+            terminated = true
+            true
+          }
+        }
+
+      if (shouldSignal) {
+        try {
+          inputStream.close()
+        } catch (_: IOException) {
+        }
+      }
+
+      return shouldSignal
+    }
+
+    private fun addDemand(
+      current: Long,
+      requested: Long,
+    ): Long {
+      val total = current + requested
+      return if (total < 0) Long.MAX_VALUE else total
+    }
+
+    companion object {
+      private const val CHUNK_SIZE = 8 * 1024
+    }
+  }
+}

--- a/jaxrs-quarkus/src/main/resources/META-INF/beans.xml
+++ b/jaxrs-quarkus/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,1 @@
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" bean-discovery-mode="annotated" version="4.0" />

--- a/jaxrs-quarkus/src/test/kotlin/io/outfoxx/sunday/jaxrs/quarkus/StreamingBufferMessageBodyReaderTest.kt
+++ b/jaxrs-quarkus/src/test/kotlin/io/outfoxx/sunday/jaxrs/quarkus/StreamingBufferMessageBodyReaderTest.kt
@@ -36,12 +36,14 @@ import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayInputStream
+import java.io.InputStream
 import java.lang.reflect.Proxy
 import java.lang.reflect.Type
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
+import java.util.concurrent.Flow
 
 class StreamingBufferMessageBodyReaderTest {
 
@@ -103,8 +105,52 @@ class StreamingBufferMessageBodyReaderTest {
     }
   }
 
+  @Test
+  fun `rejects second subscriber because request bodies are single use`() {
+    val publisher = streamingBufferPublisher()
+    val firstSubscriber = RecordingSubscriber()
+    val secondSubscriber = RecordingSubscriber()
+
+    publisher.subscribe(firstSubscriber)
+    publisher.subscribe(secondSubscriber)
+
+    assertTrue(firstSubscriber.subscribed)
+    assertTrue(secondSubscriber.subscribed)
+    assertTrue(secondSubscriber.error is IllegalStateException)
+  }
+
   @Suppress("UNCHECKED_CAST")
   private val multiBufferType = Multi::class.java as Class<Multi<Buffer>>
+
+  @Suppress("UNCHECKED_CAST")
+  private fun streamingBufferPublisher(): Flow.Publisher<Buffer> {
+    val publisherClass =
+      Class.forName("${StreamingBufferMessageBodyReader::class.java.name}\$StreamingBufferPublisher")
+    val constructor =
+      publisherClass
+        .getDeclaredConstructor(InputStream::class.java)
+        .apply { isAccessible = true }
+
+    return constructor.newInstance(ByteArrayInputStream("payload".toByteArray())) as Flow.Publisher<Buffer>
+  }
+
+  private class RecordingSubscriber : Flow.Subscriber<Buffer> {
+
+    var subscribed = false
+    var error: Throwable? = null
+
+    override fun onSubscribe(subscription: Flow.Subscription) {
+      subscribed = true
+    }
+
+    override fun onNext(item: Buffer) = Unit
+
+    override fun onError(throwable: Throwable) {
+      error = throwable
+    }
+
+    override fun onComplete() = Unit
+  }
 
   private object TypeHolder {
     val buffersType: Type = TypeHolderFields::class.java.getDeclaredField("buffers").genericType

--- a/jaxrs-quarkus/src/test/kotlin/io/outfoxx/sunday/jaxrs/quarkus/StreamingBufferMessageBodyReaderTest.kt
+++ b/jaxrs-quarkus/src/test/kotlin/io/outfoxx/sunday/jaxrs/quarkus/StreamingBufferMessageBodyReaderTest.kt
@@ -22,15 +22,21 @@ import io.smallrye.mutiny.Multi
 import io.smallrye.mutiny.Uni
 import io.vertx.mutiny.core.buffer.Buffer
 import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.InternalServerErrorException
 import jakarta.ws.rs.POST
 import jakarta.ws.rs.Path
 import jakarta.ws.rs.Produces
 import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.core.MultivaluedHashMap
+import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo
+import org.jboss.resteasy.reactive.server.spi.ServerRequestContext
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayInputStream
+import java.lang.reflect.Proxy
 import java.lang.reflect.Type
 import java.net.URI
 import java.net.http.HttpClient
@@ -44,9 +50,61 @@ class StreamingBufferMessageBodyReaderTest {
     val reader = StreamingBufferMessageBodyReader()
 
     assertTrue(reader.isReadable(Multi::class.java, TypeHolder.buffersType, emptyArray(), MediaType.WILDCARD_TYPE))
+    assertTrue(
+      reader.isReadable(
+        Multi::class.java,
+        TypeHolder.buffersType,
+        ResteasyReactiveResourceInfo("test", String::class.java, emptyArray(), false, "test"),
+        MediaType.WILDCARD_TYPE,
+      ),
+    )
+    assertFalse(reader.isReadable(Multi::class.java, Multi::class.java, emptyArray(), MediaType.WILDCARD_TYPE))
     assertFalse(reader.isReadable(Multi::class.java, TypeHolder.stringsType, emptyArray(), MediaType.WILDCARD_TYPE))
     assertFalse(reader.isReadable(String::class.java, String::class.java, emptyArray(), MediaType.WILDCARD_TYPE))
   }
+
+  @Test
+  fun `fails clearly for standard JAX-RS read path`() {
+    val reader = StreamingBufferMessageBodyReader()
+
+    assertThrows(UnsupportedOperationException::class.java) {
+      reader.readFrom(
+        multiBufferType,
+        TypeHolder.buffersType,
+        emptyArray(),
+        MediaType.WILDCARD_TYPE,
+        MultivaluedHashMap(),
+        ByteArrayInputStream(ByteArray(0)),
+      )
+    }
+  }
+
+  @Test
+  fun `fails clearly outside Vertx backed request context`() {
+    val reader = StreamingBufferMessageBodyReader()
+    val context =
+      Proxy.newProxyInstance(
+        ServerRequestContext::class.java.classLoader,
+        arrayOf(ServerRequestContext::class.java),
+      ) { _, method, _ ->
+        when (method.name) {
+          "toString" -> "TestServerRequestContext"
+          else -> error("Unexpected ServerRequestContext method: ${method.name}")
+        }
+      } as ServerRequestContext
+
+    assertThrows(InternalServerErrorException::class.java) {
+      reader.readFrom(
+        multiBufferType,
+        TypeHolder.buffersType,
+        MediaType.WILDCARD_TYPE,
+        context,
+      )
+    }
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  private val multiBufferType = Multi::class.java as Class<Multi<Buffer>>
 
   private object TypeHolder {
     val buffersType: Type = TypeHolderFields::class.java.getDeclaredField("buffers").genericType
@@ -68,6 +126,12 @@ class StreamingBufferMessageBodyReaderQuarkusTest {
 
   @Test
   fun `streams chunked request bodies into buffer multi`() {
+    val payload =
+      buildString {
+        repeat(20_000) { index ->
+          append('a' + (index % 26))
+        }
+      }
     val client = HttpClient.newHttpClient()
     val request =
       HttpRequest
@@ -75,14 +139,14 @@ class StreamingBufferMessageBodyReaderQuarkusTest {
         .header("Content-Type", MediaType.APPLICATION_OCTET_STREAM)
         .POST(
           HttpRequest.BodyPublishers.ofInputStream {
-            ByteArrayInputStream("alpha-beta-gamma".toByteArray())
+            ByteArrayInputStream(payload.toByteArray())
           },
         ).build()
 
     val response = client.send(request, HttpResponse.BodyHandlers.ofString())
 
     assertEquals(200, response.statusCode())
-    assertEquals("alpha-beta-gamma", response.body())
+    assertEquals(payload, response.body())
   }
 }
 

--- a/jaxrs-quarkus/src/test/kotlin/io/outfoxx/sunday/jaxrs/quarkus/StreamingBufferMessageBodyReaderTest.kt
+++ b/jaxrs-quarkus/src/test/kotlin/io/outfoxx/sunday/jaxrs/quarkus/StreamingBufferMessageBodyReaderTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.jaxrs.quarkus
+
+import io.quarkus.test.common.http.TestHTTPResource
+import io.quarkus.test.junit.QuarkusTest
+import io.smallrye.mutiny.Multi
+import io.smallrye.mutiny.Uni
+import io.vertx.mutiny.core.buffer.Buffer
+import jakarta.ws.rs.Consumes
+import jakarta.ws.rs.POST
+import jakarta.ws.rs.Path
+import jakarta.ws.rs.Produces
+import jakarta.ws.rs.core.MediaType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.lang.reflect.Type
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+
+class StreamingBufferMessageBodyReaderTest {
+
+  @Test
+  fun `accepts only Mutiny Multi of Vertx Mutiny buffer request bodies`() {
+    val reader = StreamingBufferMessageBodyReader()
+
+    assertTrue(reader.isReadable(Multi::class.java, TypeHolder.buffersType, emptyArray(), MediaType.WILDCARD_TYPE))
+    assertFalse(reader.isReadable(Multi::class.java, TypeHolder.stringsType, emptyArray(), MediaType.WILDCARD_TYPE))
+    assertFalse(reader.isReadable(String::class.java, String::class.java, emptyArray(), MediaType.WILDCARD_TYPE))
+  }
+
+  private object TypeHolder {
+    val buffersType: Type = TypeHolderFields::class.java.getDeclaredField("buffers").genericType
+    val stringsType: Type = TypeHolderFields::class.java.getDeclaredField("strings").genericType
+  }
+
+  @Suppress("unused")
+  private class TypeHolderFields {
+    lateinit var buffers: Multi<Buffer>
+    lateinit var strings: Multi<String>
+  }
+}
+
+@QuarkusTest
+class StreamingBufferMessageBodyReaderQuarkusTest {
+
+  @TestHTTPResource("/upload")
+  lateinit var uploadUri: URI
+
+  @Test
+  fun `streams chunked request bodies into buffer multi`() {
+    val client = HttpClient.newHttpClient()
+    val request =
+      HttpRequest
+        .newBuilder(uploadUri)
+        .header("Content-Type", MediaType.APPLICATION_OCTET_STREAM)
+        .POST(
+          HttpRequest.BodyPublishers.ofInputStream {
+            ByteArrayInputStream("alpha-beta-gamma".toByteArray())
+          },
+        ).build()
+
+    val response = client.send(request, HttpResponse.BodyHandlers.ofString())
+
+    assertEquals(200, response.statusCode())
+    assertEquals("alpha-beta-gamma", response.body())
+  }
+}
+
+@Path("/upload")
+class StreamingUploadResource {
+
+  @POST
+  @Consumes(MediaType.APPLICATION_OCTET_STREAM)
+  @Produces(MediaType.TEXT_PLAIN)
+  fun upload(body: Multi<Buffer>): Uni<String> =
+    body
+      .onItem()
+      .transform { buffer -> buffer.toString() }
+      .collect()
+      .asList()
+      .map { chunks -> chunks.joinToString("") }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,6 +24,7 @@ include(
   "core",
   "okhttp",
   "jdk",
+  "jaxrs-quarkus",
   "problem",
   "problem-quarkus",
   "problem-zalando",
@@ -33,6 +34,7 @@ include(
 project(":core").name = "sunday-core"
 project(":okhttp").name = "sunday-okhttp"
 project(":jdk").name = "sunday-jdk"
+project(":jaxrs-quarkus").name = "sunday-jaxrs-quarkus"
 project(":problem").name = "sunday-problem"
 project(":problem-quarkus").name = "sunday-problem-quarkus"
 project(":problem-zalando").name = "sunday-problem-zalando"


### PR DESCRIPTION
Summary
- Add the sunday-jaxrs-quarkus runtime module.
- Register a Quarkus RESTEasy Reactive ServerMessageBodyReader for Multi<Buffer> request bodies.
- Add type matching and Quarkus chunked upload integration coverage.

Details
- Publishes io.outfoxx.sunday:sunday-jaxrs-quarkus alongside the existing sunday-kt modules.
- The provider only accepts Multi<io.vertx.mutiny.core.buffer.Buffer> request bodies.
- The server reader exposes a cold Multi backed by the Quarkus Vert.x request input stream and reads on Mutiny worker execution.

Validation
- ./gradlew :sunday-jaxrs-quarkus:test :sunday-jaxrs-quarkus:ktlintCheck :sunday-jaxrs-quarkus:check --rerun-tasks