### PR TITLE
Add Sunday broker runtime SPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Artifacts
 - `sunday-okhttp`: OkHttp-based transport implementation.
 - `sunday-jdk`: JDK `HttpClient`-based transport implementation.
 - `sunday-jaxrs-quarkus`: Quarkus REST/JAX-RS support utilities.
+- `sunday-broker`: Protocol-neutral broker operation support for generated AsyncAPI clients.
 - `sunday-problem`: Default RFC7807 problem type (`SundayHttpProblem`) and adapters.
 - `sunday-problem-quarkus`: Quarkus `HttpProblem` integration.
 - `sunday-problem-zalando`: Zalando `problem` integration.

--- a/broker/build.gradle.kts
+++ b/broker/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+  id("library.conventions")
+}
+
+dependencies {
+
+  api(project(":sunday-core"))
+}

--- a/broker/src/main/kotlin/io/outfoxx/sunday/broker/BrokerConsumer.kt
+++ b/broker/src/main/kotlin/io/outfoxx/sunday/broker/BrokerConsumer.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.broker
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Consumes generated broker messages using an application-provided transport.
+ */
+interface BrokerConsumer {
+
+  /** Consume raw deliveries matching [spec]. */
+  fun consume(spec: BrokerConsumeSpec): Flow<BrokerRawDelivery>
+}

--- a/broker/src/main/kotlin/io/outfoxx/sunday/broker/BrokerDelivery.kt
+++ b/broker/src/main/kotlin/io/outfoxx/sunday/broker/BrokerDelivery.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.broker
+
+/**
+ * A raw broker delivery plus explicit acknowledgment control.
+ */
+interface BrokerRawDelivery {
+
+  /** Message carried by the delivery. */
+  val message: BrokerMessage
+
+  /** Source exchange, when the transport exposes one. */
+  val exchange: String?
+
+  /** Source routing key, when the transport exposes one. */
+  val routingKey: String?
+
+  /** Whether the transport reports this delivery as redelivered. */
+  val redelivered: Boolean
+
+  /** Acknowledge successful processing. */
+  suspend fun ack()
+
+  /** Negatively acknowledge processing failure. */
+  suspend fun nack(requeue: Boolean)
+}
+
+/**
+ * A decoded broker delivery that preserves the raw acknowledgment handle.
+ */
+class BrokerDelivery<T : Any>(
+  val body: T,
+  val raw: BrokerRawDelivery,
+) {
+
+  /** Acknowledge successful processing. */
+  suspend fun ack() = raw.ack()
+
+  /** Negatively acknowledge processing failure. */
+  suspend fun nack(requeue: Boolean) = raw.nack(requeue)
+}

--- a/broker/src/main/kotlin/io/outfoxx/sunday/broker/BrokerMessage.kt
+++ b/broker/src/main/kotlin/io/outfoxx/sunday/broker/BrokerMessage.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.broker
+
+/**
+ * A protocol-neutral broker message body plus transport metadata.
+ */
+data class BrokerMessage(
+  val body: ByteArray,
+  val contentType: String? = null,
+  val headers: Map<String, Any?> = emptyMap(),
+  val routingKey: String? = null,
+)

--- a/broker/src/main/kotlin/io/outfoxx/sunday/broker/BrokerMessageCodec.kt
+++ b/broker/src/main/kotlin/io/outfoxx/sunday/broker/BrokerMessageCodec.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.broker
+
+import io.outfoxx.sunday.MediaType
+import io.outfoxx.sunday.mediatypes.codecs.MediaTypeDecoders
+import io.outfoxx.sunday.mediatypes.codecs.MediaTypeEncoders
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
+import kotlinx.io.write
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
+
+/**
+ * Encodes and decodes broker payloads using Sunday media type codecs.
+ */
+class BrokerMessageCodec(
+  private val encoders: MediaTypeEncoders = MediaTypeEncoders.default,
+  private val decoders: MediaTypeDecoders = MediaTypeDecoders.default,
+) {
+
+  /**
+   * Encode [value] as a broker message.
+   */
+  fun <T : Any> encode(
+    value: T,
+    contentType: String?,
+    headers: Map<String, Any?> = emptyMap(),
+    routingKey: String? = null,
+  ): BrokerMessage {
+    val mediaType = contentType?.let(MediaType::from) ?: MediaType.JSON
+    val encoder =
+      encoders.find(mediaType)
+        ?: throw BrokerCodecException("No broker encoder registered for media type '$mediaType'")
+    return BrokerMessage(
+      body = encoder.encode(value).readByteArray(),
+      contentType = contentType,
+      headers = headers,
+      routingKey = routingKey,
+    )
+  }
+
+  /**
+   * Decode [delivery] into [type].
+   */
+  fun <T : Any> decode(
+    delivery: BrokerRawDelivery,
+    type: KType,
+  ): T {
+    val contentType = delivery.message.contentType ?: MediaType.JSON.toString()
+    val mediaType = MediaType.from(contentType)
+    val decoder =
+      decoders.find(mediaType)
+        ?: throw BrokerCodecException("No broker decoder registered for media type '$mediaType'")
+    val buffer = Buffer()
+    buffer.write(delivery.message.body)
+    return decoder.decode(buffer, type)
+  }
+}
+
+/**
+ * Decode [delivery] using the reified Kotlin type.
+ */
+inline fun <reified T : Any> BrokerMessageCodec.decode(delivery: BrokerRawDelivery): T = decode(delivery, typeOf<T>())
+
+/**
+ * Raised when broker payload codecs cannot encode or decode a message.
+ */
+class BrokerCodecException(
+  message: String,
+  cause: Throwable? = null,
+) : RuntimeException(message, cause)

--- a/broker/src/main/kotlin/io/outfoxx/sunday/broker/BrokerOperationSpecs.kt
+++ b/broker/src/main/kotlin/io/outfoxx/sunday/broker/BrokerOperationSpecs.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.broker
+
+/**
+ * Describes a generated broker send operation.
+ */
+data class BrokerSendSpec(
+  val id: String,
+  val channel: String,
+  val contentType: String? = null,
+  val protocol: BrokerProtocolSpec,
+)
+
+/**
+ * Describes a generated broker consume operation.
+ */
+data class BrokerConsumeSpec(
+  val id: String,
+  val channel: String,
+  val contentType: String? = null,
+  val protocol: BrokerProtocolSpec,
+)

--- a/broker/src/main/kotlin/io/outfoxx/sunday/broker/BrokerProducer.kt
+++ b/broker/src/main/kotlin/io/outfoxx/sunday/broker/BrokerProducer.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.broker
+
+/**
+ * Sends generated broker messages using an application-provided transport.
+ */
+interface BrokerProducer {
+
+  /** Send [message] according to [spec], suspending until the transport accepts it. */
+  suspend fun send(
+    spec: BrokerSendSpec,
+    message: BrokerMessage,
+  )
+}

--- a/broker/src/main/kotlin/io/outfoxx/sunday/broker/BrokerProtocolSpec.kt
+++ b/broker/src/main/kotlin/io/outfoxx/sunday/broker/BrokerProtocolSpec.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.broker
+
+/**
+ * Protocol-specific metadata for a generated broker operation.
+ */
+interface BrokerProtocolSpec {
+
+  /** Source protocol name, such as `amqp`. */
+  val protocol: String
+}
+
+/**
+ * AMQP/RabbitMQ metadata for a generated broker operation.
+ */
+data class AmqpBrokerProtocolSpec(
+  val exchange: String? = null,
+  val exchangeType: String? = null,
+  val queue: String? = null,
+  val routingKeys: List<String> = emptyList(),
+  val defaultRoutingKey: String? = null,
+  val durable: Boolean? = null,
+  val autoDelete: Boolean? = null,
+  val deadLetterExchange: String? = null,
+  val deadLetterRoutingKey: String? = null,
+) : BrokerProtocolSpec {
+
+  override val protocol: String = "amqp"
+}

--- a/broker/src/test/kotlin/io/outfoxx/sunday/broker/BrokerMessageCodecTest.kt
+++ b/broker/src/test/kotlin/io/outfoxx/sunday/broker/BrokerMessageCodecTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday.broker
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+
+class BrokerMessageCodecTest {
+
+  @Test
+  fun `round trips JSON payloads`() {
+    val codec = BrokerMessageCodec()
+    val message = codec.encode(TestMessage("one", 42), contentType = "application/json", routingKey = "test.one")
+
+    expectThat(message.contentType).isEqualTo("application/json")
+    expectThat(message.routingKey).isEqualTo("test.one")
+
+    val decoded = codec.decode<TestMessage>(TestDelivery(message))
+
+    expectThat(decoded).isEqualTo(TestMessage("one", 42))
+  }
+
+  @Test
+  fun `delegates ack and nack from decoded delivery`() =
+    runTest {
+      val raw = TestDelivery(BrokerMessage(ByteArray(0)))
+      val delivery = BrokerDelivery(TestMessage("one", 42), raw)
+
+      delivery.ack()
+      delivery.nack(requeue = true)
+
+      expectThat(raw.actions.toList()).isEqualTo(listOf("ack", "nack:true"))
+    }
+
+  @Test
+  fun `broker specs preserve AMQP metadata`() {
+    val spec =
+      BrokerConsumeSpec(
+        id = "consumePlatformEvents",
+        channel = "platform.events",
+        contentType = "application/json",
+        protocol =
+          AmqpBrokerProtocolSpec(
+            exchange = "platform.events",
+            exchangeType = "topic",
+            queue = "platform-events",
+            routingKeys = listOf("#"),
+            deadLetterExchange = "platform.events.dlx",
+          ),
+      )
+
+    val amqp = spec.protocol as AmqpBrokerProtocolSpec
+
+    expectThat(spec.channel).isEqualTo("platform.events")
+    expectThat(amqp.exchange).isEqualTo("platform.events")
+    expectThat(amqp.routingKeys).isEqualTo(listOf("#"))
+    expectThat(amqp.deadLetterExchange).isEqualTo("platform.events.dlx")
+  }
+
+  data class TestMessage(
+    val id: String,
+    val count: Int,
+  )
+
+  private class TestDelivery(
+    override val message: BrokerMessage,
+  ) : BrokerRawDelivery {
+
+    val actions = mutableListOf<String>()
+
+    override val exchange: String = "test.exchange"
+    override val routingKey: String = message.routingKey ?: "test.key"
+    override val redelivered: Boolean = false
+
+    override suspend fun ack() {
+      actions += "ack"
+    }
+
+    override suspend fun nack(requeue: Boolean) {
+      actions += "nack:$requeue"
+    }
+  }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ val releaseVersion: String by project
 group = "io.outfoxx.sunday"
 version = releaseVersion
 
-val moduleNames = listOf("core", "jdk", "okhttp", "jaxrs-quarkus", "problem", "problem-quarkus", "problem-zalando")
+val moduleNames = listOf("core", "jdk", "okhttp", "jaxrs-quarkus", "broker", "problem", "problem-quarkus", "problem-zalando")
 
 //
 // ANALYSIS

--- a/code-coverage/build.gradle.kts
+++ b/code-coverage/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
   kover(project(":sunday-jdk"))
   kover(project(":sunday-okhttp"))
   kover(project(":sunday-jaxrs-quarkus"))
+  kover(project(":sunday-broker"))
   kover(project(":sunday-problem"))
   kover(project(":sunday-problem-quarkus"))
   kover(project(":sunday-problem-zalando"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,6 +25,7 @@ include(
   "okhttp",
   "jdk",
   "jaxrs-quarkus",
+  "broker",
   "problem",
   "problem-quarkus",
   "problem-zalando",
@@ -35,6 +36,7 @@ project(":core").name = "sunday-core"
 project(":okhttp").name = "sunday-okhttp"
 project(":jdk").name = "sunday-jdk"
 project(":jaxrs-quarkus").name = "sunday-jaxrs-quarkus"
+project(":broker").name = "sunday-broker"
 project(":problem").name = "sunday-problem"
 project(":problem-quarkus").name = "sunday-problem-quarkus"
 project(":problem-zalando").name = "sunday-problem-zalando"


### PR DESCRIPTION
## Summary

Adds a new `sunday-broker` runtime module that generated AsyncAPI broker facades can target without depending on a specific AMQP/RabbitMQ client implementation.

## Details

- Adds protocol-neutral broker producer and consumer SPIs.
- Adds broker operation specs for generated send and consume operations.
- Adds AMQP/RabbitMQ metadata via `AmqpBrokerProtocolSpec`.
- Adds `BrokerMessageCodec` for Sunday media type encoder/decoder based payload handling.
- Registers the new module in settings, module publishing, coverage, and README artifact documentation.

## Validation

- `./gradlew :sunday-broker:check --rerun-tasks`
- Published local `999-SNAPSHOT` artifacts for runtime smoke use.
