### PR TITLE
Fix Quarkus sources jar publish wiring

### DIFF
--- a/jaxrs-quarkus/build.gradle.kts
+++ b/jaxrs-quarkus/build.gradle.kts
@@ -11,6 +11,10 @@ tasks.matching { it.name == "runKtlintCheckOverMainSourceSet" }.configureEach {
   dependsOn("compileQuarkusGeneratedSourcesJava")
 }
 
+tasks.matching { it.name == "sourcesJar" }.configureEach {
+  dependsOn("compileQuarkusGeneratedSourcesJava")
+}
+
 dependencies {
 
   implementation(enforcedPlatform(libs.quarkus.bom))


### PR DESCRIPTION
## Summary

Fixes the `sunday-jaxrs-quarkus` sources jar task wiring so the snapshot publish workflow can build after the Quarkus streaming module was added.

## Details

The Quarkus Gradle plugin creates generated-source compile tasks that produce outputs under the `quarkus-generated-sources` source set. The module already makes Kotlin compilation and ktlint wait for `compileQuarkusGeneratedSourcesJava`; this adds the same dependency for the lazily registered `sourcesJar` task.

Without this, Gradle 9 reports an implicit dependency validation error during `./gradlew build dokkaGeneratePublicationHtml -x test`.

## Validation

- `./gradlew build dokkaGeneratePublicationHtml -x test --rerun-tasks`
