### PR TITLE
Fix Quarkus Maven publish wiring

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
   alias(libs.plugins.sonarqube)
   alias(libs.plugins.dokka)
   alias(libs.plugins.github.release)
+  alias(libs.plugins.maven.publish) apply false
   alias(libs.plugins.kotlin.jvm) apply false // Required by dokka
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -90,3 +90,4 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 github-release = { id = "com.github.breadmoirai.github-release", version.ref = "githubRelease" }
 sonarqube = { id = "org.sonarqube", version.ref = "sonarqube" }
 quarkus = { id = "io.quarkus", version.ref = "quarkus" }
+maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "vanniktechPublish" }

--- a/jaxrs-quarkus/build.gradle.kts
+++ b/jaxrs-quarkus/build.gradle.kts
@@ -15,9 +15,13 @@ tasks.matching { it.name == "sourcesJar" }.configureEach {
   dependsOn("compileQuarkusGeneratedSourcesJava")
 }
 
+tasks.matching { it.name.startsWith("dokkaGeneratePublication") }.configureEach {
+  dependsOn("compileQuarkusGeneratedSourcesJava")
+}
+
 dependencies {
 
-  implementation(enforcedPlatform(libs.quarkus.bom))
+  implementation(platform(libs.quarkus.bom))
 
   api(libs.mutiny)
   api(libs.mutiny.vertx.core)


### PR DESCRIPTION
## Summary

Fixes the remaining `sunday-jaxrs-quarkus` Maven publication failures exposed after PR #48 unblocked source jar generation.

## Details

- Adds the Vanniktech Maven Publish plugin to the root plugin classpath with `apply false` so sibling modules share the Maven Central build service classloader.
- Makes Quarkus Dokka publication tasks depend on `compileQuarkusGeneratedSourcesJava`, matching the sources jar and ktlint/generated-source ordering.
- Publishes the Quarkus BOM as a normal platform instead of an enforced platform so Gradle module metadata does not leak forced dependencies to consumers.

## Validation

- `./gradlew build dokkaGeneratePublicationHtml -x test --rerun-tasks`
- `./gradlew publishToMavenLocal --rerun-tasks`
