### PR TITLE
Align EventSource reconnection policy

### DIFF
--- a/core/src/main/kotlin/io/outfoxx/sunday/EventParser.kt
+++ b/core/src/main/kotlin/io/outfoxx/sunday/EventParser.kt
@@ -47,6 +47,16 @@ class EventParser {
     var data: String? = null,
   ) {
 
+    /**
+     * SSE keepalive interval extension field.
+     */
+    var keepalive: String? = null
+
+    /**
+     * SSE maximum retry interval extension field.
+     */
+    var retryMax: String? = null
+
     fun toEvent(origin: String) = EventSource.Event(event, id, data, origin)
 
   }
@@ -191,6 +201,10 @@ class EventParser {
 
         when (key) {
           "retry" -> info.retry = trimEventField(string = value)
+
+          "retry-max" -> info.retryMax = trimEventField(string = value)
+
+          "keepalive" -> info.keepalive = trimEventField(string = value)
 
           "event" -> info.event = trimEventField(string = value)
 

--- a/core/src/main/kotlin/io/outfoxx/sunday/EventSource.kt
+++ b/core/src/main/kotlin/io/outfoxx/sunday/EventSource.kt
@@ -636,7 +636,7 @@ class EventSource(
     val retryMax = info.retryMax
     if (retryMax != null) {
       val retryTimeMax = retryMax.trim().toLongOrNull(radix = 10)
-      if (retryTimeMax != null && retryTimeMax >= 0) {
+      if (retryTimeMax != null && retryTimeMax > 0) {
         logger.debug("update maximum retry timeout: retryTimeMax=$retryTimeMax")
 
         this.retryTimeMaxValue = Duration.ofMillis(retryTimeMax)

--- a/core/src/main/kotlin/io/outfoxx/sunday/EventSource.kt
+++ b/core/src/main/kotlin/io/outfoxx/sunday/EventSource.kt
@@ -33,15 +33,12 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.io.Buffer
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.Closeable
-import java.lang.Double.max
-import java.lang.Double.min
 import java.net.SocketException
 import java.net.URI
 import java.time.Duration
@@ -54,7 +51,9 @@ import kotlin.concurrent.read
 import kotlin.concurrent.schedule
 import kotlin.concurrent.scheduleAtFixedRate
 import kotlin.concurrent.write
+import kotlin.math.min
 import kotlin.math.pow
+import kotlin.random.Random
 
 /**
  * Server-Sent Events stream client.
@@ -66,7 +65,7 @@ class EventSource(
   private val requestSupplier: suspend (Headers) -> Request,
   private val problemFactory: ProblemFactory,
   retryTime: Duration = retryTimeDefault,
-  private val eventTimeout: Duration? = eventTimeoutDefault,
+  eventTimeout: Duration? = eventTimeoutDefault,
   private val eventTimeoutCheckInterval: Duration = eventTimeoutCheckIntervalDefault,
   private val logger: Logger = LoggerFactory.getLogger(EventSource::class.java),
 ) : Closeable {
@@ -111,7 +110,7 @@ class EventSource(
      * Each [EventSource] can override this setting in its constructor using the `eventTimeout`
      * constructor parameter.
      */
-    var eventTimeoutDefault: Duration = Duration.of(75, ChronoUnit.SECONDS)
+    var eventTimeoutDefault: Duration? = null
 
     /**
      * Global default time interval for event timeout checks.
@@ -126,19 +125,61 @@ class EventSource(
     /**
      * Global default read timeout for [EventSource] http clients.
      *
-     * If data is not received without the read timeout, a cancellation error
+     * If data is not received within the read timeout, a cancellation error
      * will cause a reconnection attempt to be initiated.
+     * A zero duration disables the transport read timeout.
      *
      * Note: [EventSource]s can override the HTTP read timeout by customizing the `httpClient`
      * constructor parameters. This default applies to instances that use a system create
      * client.
      */
-    var httpReadTimeoutDefault: Duration = Duration.ofMinutes(10)
+    var httpReadTimeoutDefault: Duration = Duration.ZERO
 
     private fun createRequestEventScope(): CoroutineScope =
       CoroutineScope(CoroutineName("EventSource - Request Processor"))
 
-    private const val MAX_RETRY_TIME_MULTIPLE = 30.0
+    private const val DEFAULT_RETRY_TIME_MAX_MULTIPLE = 30L
+    private const val KEEPALIVE_TIMEOUT_MULTIPLE = 3L
+    private const val RETRY_JITTER_MIN = 0.9
+    private val keepaliveTimeoutFloor = Duration.ofSeconds(1)
+
+    internal fun calculateRetryDelay(
+      retryAttempt: Int,
+      retryTime: Duration,
+      retryTimeMax: Duration,
+      jitter: Double,
+    ): Duration {
+      val retryTimeMs = retryTime.toMillis().toDouble()
+      val retryTimeMaxMs = retryTimeMax.toMillis().toDouble()
+      val exponentialDelayMs = retryTimeMs * 2.0.pow(retryAttempt)
+      val cappedDelayMs = min(exponentialDelayMs, retryTimeMaxMs)
+
+      return Duration.ofMillis((cappedDelayMs * jitter).toLong())
+    }
+
+    internal fun calculateEventTimeout(keepaliveTime: Duration): Duration {
+      val keepaliveTimeMs = keepaliveTime.toMillis()
+      val advertisedTimeoutMs =
+        if (keepaliveTimeMs > Long.MAX_VALUE / KEEPALIVE_TIMEOUT_MULTIPLE) {
+          Long.MAX_VALUE
+        } else {
+          keepaliveTimeMs * KEEPALIVE_TIMEOUT_MULTIPLE
+        }
+
+      return Duration.ofMillis(maxOf(advertisedTimeoutMs, keepaliveTimeoutFloor.toMillis()))
+    }
+
+    private fun calculateDefaultRetryTimeMax(retryTime: Duration): Duration {
+      val retryTimeMs = retryTime.toMillis()
+      val retryTimeMaxMs =
+        if (retryTimeMs > Long.MAX_VALUE / DEFAULT_RETRY_TIME_MAX_MULTIPLE) {
+          Long.MAX_VALUE
+        } else {
+          retryTimeMs * DEFAULT_RETRY_TIME_MAX_MULTIPLE
+        }
+
+      return Duration.ofMillis(retryTimeMaxMs)
+    }
   }
 
   /**
@@ -181,6 +222,27 @@ class EventSource(
     get() = retryTimeValue
   private var retryTimeValue = retryTime
 
+  /**
+   * Current maximum retry time.
+   *
+   * The server can update this value using the `retry-max` SSE extension field.
+   */
+  val retryTimeMax: Duration
+    get() = retryTimeMaxValue ?: calculateDefaultRetryTimeMax(retryTime)
+  private var retryTimeMaxValue: Duration? = null
+
+  private val configuredEventTimeout = eventTimeout
+  private var serverEventTimeout: Duration? = null
+
+  /**
+   * Current event timeout.
+   *
+   * An explicit constructor value takes precedence over the timeout derived from a server's
+   * `keepalive` SSE extension field. Without either value, event timeouts are disabled.
+   */
+  val eventTimeout: Duration?
+    get() = configuredEventTimeout ?: serverEventTimeout
+
   private var openHandler: (() -> Unit)? = null
   private var errorHandler: ((error: Throwable?) -> Unit)? = null
   private var messageHandler: ((event: Event) -> Unit)? = null
@@ -188,7 +250,6 @@ class EventSource(
 
   private var retryAttempt = 0
   private var currentRequest: Job? = null
-  private var connectionAttemptTime: Instant? = null
   private var connectionOrigin: URI? = null
   private var reconnectTimerTask: TimerTask? = null
   private var lastEventId: String? = null
@@ -303,8 +364,6 @@ class EventSource(
       headers = headers.plus(LAST_EVENT_ID to it)
     }
 
-    connectionAttemptTime = Instant.now()
-
     val request = requestSupplier(headers)
 
     currentRequest =
@@ -312,13 +371,7 @@ class EventSource(
         try {
           request
             .start()
-            .onCompletion {
-              if (it != null) {
-                receivedError(it)
-              } else {
-                receivedComplete()
-              }
-            }.collect(::dispatchEvent)
+            .collect(::dispatchEvent)
 
         } catch (_: CancellationException) {
           // do nothing
@@ -335,8 +388,14 @@ class EventSource(
 
     when (event) {
       is Request.Event.Start -> {
+        if (event.value.statusCode == 204) {
+          close()
+          return
+        }
+
         if (!event.value.isSuccessful) {
-          receivedError(problemFactory.from(event.value).build())
+          receivedFatalError(problemFactory.from(event.value).build())
+          return
         }
 
         receivedResponse(event.value)
@@ -488,6 +547,18 @@ class EventSource(
     }
   }
 
+  private fun receivedFatalError(t: Throwable) {
+    if (readyStateValue.isClosed) {
+      return
+    }
+
+    logger.error("Received: fatal error", t)
+
+    stateLock.read { errorHandler }?.invoke(t)
+
+    close()
+  }
+
   private fun receivedComplete() {
     if (readyStateValue.isClosed) {
       return
@@ -515,14 +586,13 @@ class EventSource(
       return
     }
 
-    val lastConnectTime =
-      if (connectionAttemptTime != null) {
-        Duration.between(connectionAttemptTime, Instant.now())
+    val jitter =
+      if (retryAttempt == 0) {
+        1.0
       } else {
-        Duration.ZERO
+        Random.nextDouble(RETRY_JITTER_MIN, 1.0)
       }
-
-    val retryDelay = calculateRetryDelay(retryAttempt, retryTime, lastConnectTime)
+    val retryDelay = calculateRetryDelay(retryAttempt, retryTime, retryTimeMax, jitter)
 
     logger.debug("Scheduling reconnect in {}", retryDelay)
 
@@ -542,35 +612,6 @@ class EventSource(
     reconnectTimerTask = null
   }
 
-  private fun calculateRetryDelay(
-    retryAttempt: Int,
-    retryTime: Duration,
-    lastConnectTime: Duration,
-  ): Duration {
-    val retryTimeMs = retryTime.toMillis()
-
-    // calculate total delay
-    val backOffDelayMs = retryAttempt.toDouble().pow(2) * retryTimeMs
-    var retryDelayMs =
-      min(
-        retryTimeMs + backOffDelayMs,
-        retryTimeMs * MAX_RETRY_TIME_MULTIPLE,
-      )
-
-    // Adjust delay by the amount of time the last connection
-    // cycle took, except on the first attempt
-    if (retryAttempt > 0) {
-      retryDelayMs -= lastConnectTime.toMillis()
-
-      // Ensure the delay is at least as large as
-      // a minimum retry time interval
-      retryDelayMs = max(retryDelayMs, retryTimeMs.toDouble())
-    }
-
-    return Duration.ofMillis(retryDelayMs.toLong())
-  }
-
-
   /**
    * Event Dispatching
    */
@@ -583,12 +624,37 @@ class EventSource(
     val retry = info.retry
     if (retry != null) {
       val retryTime = retry.trim().toLongOrNull(radix = 10)
-      if (retryTime != null) {
+      if (retryTime != null && retryTime >= 0) {
         logger.debug("update retry timeout: retryTime=$retryTime")
 
         this.retryTimeValue = Duration.ofMillis(retryTime)
       } else {
         logger.warn("ignoring invalid retry timeout message: retry=$retry")
+      }
+    }
+
+    val retryMax = info.retryMax
+    if (retryMax != null) {
+      val retryTimeMax = retryMax.trim().toLongOrNull(radix = 10)
+      if (retryTimeMax != null && retryTimeMax >= 0) {
+        logger.debug("update maximum retry timeout: retryTimeMax=$retryTimeMax")
+
+        this.retryTimeMaxValue = Duration.ofMillis(retryTimeMax)
+      } else {
+        logger.warn("ignoring invalid maximum retry timeout message: retryMax=$retryMax")
+      }
+    }
+
+    val keepalive = info.keepalive
+    if (keepalive != null) {
+      val keepaliveTime = keepalive.trim().toLongOrNull(radix = 10)
+      if (keepaliveTime != null && keepaliveTime > 0) {
+        logger.debug("update keepalive interval: keepaliveTime=$keepaliveTime")
+
+        serverEventTimeout = calculateEventTimeout(Duration.ofMillis(keepaliveTime))
+        startEventTimeoutCheck(lastEventReceivedTime)
+      } else {
+        logger.warn("ignoring invalid keepalive message: keepalive=$keepalive")
       }
     }
 

--- a/core/src/test/kotlin/EventParserTest.kt
+++ b/core/src/test/kotlin/EventParserTest.kt
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test
 import strikt.api.expectThat
 import strikt.assertions.containsExactlyInAnyOrder
 import strikt.assertions.hasSize
+import strikt.assertions.isEqualTo
 import java.lang.Integer.min
 import kotlin.random.Random
 
@@ -143,6 +144,17 @@ class EventParserTest {
 
     expectThat(events).hasSize(1)
     expectThat(events).containsExactlyInAnyOrder(EventInfo("", "", "", ""))
+  }
+
+  @Test
+  fun `parses reconnection control fields`() {
+    val eventBuffer = source("keepalive: 5000\nretry-max: 30000\n\n")
+
+    val events = run(EventParser(), eventBuffer)
+
+    expectThat(events).hasSize(1)
+    expectThat(events[0].keepalive).isEqualTo("5000")
+    expectThat(events[0].retryMax).isEqualTo("30000")
   }
 
   @Test

--- a/core/src/test/kotlin/io/outfoxx/sunday/EventSourceReconnectPolicyTest.kt
+++ b/core/src/test/kotlin/io/outfoxx/sunday/EventSourceReconnectPolicyTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Outfox, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.outfoxx.sunday
+
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+import java.time.Duration
+
+class EventSourceReconnectPolicyTest {
+
+  @Test
+  fun `retry delay grows exponentially and respects the maximum`() {
+    val retryTime = Duration.ofMillis(500)
+    val retryTimeMax = Duration.ofSeconds(15)
+
+    val delays =
+      (0..6).map { attempt ->
+        EventSource.calculateRetryDelay(attempt, retryTime, retryTimeMax, jitter = 1.0)
+      }
+
+    expectThat(delays).isEqualTo(
+      listOf(
+        Duration.ofMillis(500),
+        Duration.ofSeconds(1),
+        Duration.ofSeconds(2),
+        Duration.ofSeconds(4),
+        Duration.ofSeconds(8),
+        Duration.ofSeconds(15),
+        Duration.ofSeconds(15),
+      ),
+    )
+  }
+
+  @Test
+  fun `retry jitter only reduces the exponential delay`() {
+    val delay =
+      EventSource.calculateRetryDelay(
+        retryAttempt = 2,
+        retryTime = Duration.ofMillis(500),
+        retryTimeMax = Duration.ofSeconds(15),
+        jitter = 0.9,
+      )
+
+    expectThat(delay).isEqualTo(Duration.ofMillis(1800))
+  }
+
+  @Test
+  fun `keepalive timeout tolerates missed signals and applies a floor`() {
+    expectThat(EventSource.calculateEventTimeout(Duration.ofMillis(500)))
+      .isEqualTo(Duration.ofMillis(1500))
+    expectThat(EventSource.calculateEventTimeout(Duration.ofMillis(100)))
+      .isEqualTo(Duration.ofSeconds(1))
+  }
+}

--- a/core/src/testFixtures/kotlin/io/outfoxx/sunday/test/EventSourceTest.kt
+++ b/core/src/testFixtures/kotlin/io/outfoxx/sunday/test/EventSourceTest.kt
@@ -35,9 +35,13 @@ import org.junit.jupiter.api.Timeout
 import strikt.api.expectThat
 import strikt.assertions.isEmpty
 import strikt.assertions.isEqualTo
+import strikt.assertions.isFalse
+import strikt.assertions.isLessThan
 import strikt.assertions.isNotNull
+import strikt.assertions.isNull
 import strikt.assertions.isTrue
 import java.time.Duration
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit.MILLISECONDS
 import java.util.concurrent.TimeUnit.SECONDS
@@ -346,6 +350,270 @@ abstract class EventSourceTest {
 
         expectThat(completed.await(3, SECONDS)).isTrue()
         expectThat(eventSource.retryTime).isEqualTo(Duration.ofMillis(500L))
+      }
+    }
+  }
+
+  @Test
+  fun `server controls retry maximum and event timeout`() {
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .addHeader(CONTENT_TYPE, EventStream)
+        .setBody(
+          """
+          |retry-max: 3000
+          |keepalive: 500
+          |data: some test data
+          |
+          |
+          """.trimMargin(),
+        ),
+    )
+    server.start()
+    server.use {
+      val eventSource =
+        EventSource(
+          { headers -> createRequest(server.url("/test").toString(), headers) },
+          SundayHttpProblem.Factory,
+        )
+
+      val completed = CountDownLatch(1)
+      eventSource.onMessage = { completed.countDown() }
+
+      eventSource.use {
+        eventSource.connect()
+
+        expectThat(completed.await(3, SECONDS)).isTrue()
+        expectThat(eventSource.retryTimeMax).isEqualTo(Duration.ofSeconds(3))
+        expectThat(eventSource.eventTimeout).isEqualTo(Duration.ofMillis(1500))
+      }
+    }
+  }
+
+  @Test
+  fun `explicit event timeout overrides server keepalive`() {
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .addHeader(CONTENT_TYPE, EventStream)
+        .setBody(
+          """
+          |keepalive: 5000
+          |data: some test data
+          |
+          |
+          """.trimMargin(),
+        ),
+    )
+    server.start()
+    server.use {
+      val eventSource =
+        EventSource(
+          { headers -> createRequest(server.url("/test").toString(), headers) },
+          SundayHttpProblem.Factory,
+          eventTimeout = Duration.ofMillis(250),
+        )
+
+      val completed = CountDownLatch(1)
+      eventSource.onMessage = { completed.countDown() }
+
+      eventSource.use {
+        eventSource.connect()
+
+        expectThat(completed.await(3, SECONDS)).isTrue()
+        expectThat(eventSource.eventTimeout).isEqualTo(Duration.ofMillis(250))
+      }
+    }
+  }
+
+  @Test
+  fun `invalid reconnection controls are ignored`() {
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .addHeader(CONTENT_TYPE, EventStream)
+        .setBody(
+          """
+          |retry: -1
+          |retry-max: -1
+          |keepalive: 0
+          |data: some test data
+          |
+          |
+          """.trimMargin(),
+        ),
+    )
+    server.start()
+    server.use {
+      val eventSource =
+        EventSource(
+          { headers -> createRequest(server.url("/test").toString(), headers) },
+          SundayHttpProblem.Factory,
+        )
+
+      val completed = CountDownLatch(1)
+      eventSource.onMessage = { completed.countDown() }
+
+      eventSource.use {
+        eventSource.connect()
+
+        expectThat(completed.await(3, SECONDS)).isTrue()
+        expectThat(eventSource.retryTime).isEqualTo(Duration.ofMillis(500))
+        expectThat(eventSource.retryTimeMax).isEqualTo(Duration.ofSeconds(15))
+        expectThat(eventSource.eventTimeout).isNull()
+      }
+    }
+  }
+
+  @Test
+  fun `comment-only blocks reset event timeout activity`() {
+    val keepaliveBlock = "keepalive: 100\n\n"
+    val commentBlock = ": 123456789012\n\n"
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .addHeader(CONTENT_TYPE, EventStream)
+        .setChunkedBody(keepaliveBlock + commentBlock.repeat(10), keepaliveBlock.length)
+        .throttleBody(keepaliveBlock.length.toLong(), 600, MILLISECONDS),
+    )
+    server.start()
+    server.use {
+      val eventSource =
+        EventSource(
+          { headers -> createRequest(server.url("/test").toString(), headers) },
+          SundayHttpProblem.Factory,
+          eventTimeoutCheckInterval = Duration.ofMillis(50),
+        )
+
+      val opened = CountDownLatch(1)
+      val timedOut = CountDownLatch(1)
+      eventSource.onOpen = { opened.countDown() }
+      eventSource.onError = {
+        if (it is EventSourceError && it.reason == EventTimeout) {
+          timedOut.countDown()
+        }
+      }
+
+      eventSource.use {
+        eventSource.connect()
+
+        expectThat(opened.await(3, SECONDS)).isTrue()
+        expectThat(timedOut.await(2500, MILLISECONDS)).isFalse()
+      }
+    }
+  }
+
+  @Test
+  fun `event timeout is disabled without an override or keepalive`() {
+    val eventSource =
+      EventSource(
+        { headers -> createRequest("http://example.com", headers) },
+        SundayHttpProblem.Factory,
+      )
+
+    expectThat(eventSource.eventTimeout).isNull()
+  }
+
+  @Test
+  fun `clean server close resets retry escalation`() {
+    val server = MockWebServer()
+    repeat(5) {
+      server.enqueue(
+        MockResponse()
+          .setResponseCode(200)
+          .addHeader(CONTENT_TYPE, EventStream),
+      )
+    }
+    server.enqueue(MockResponse().setResponseCode(204))
+    server.start()
+    server.use {
+      val opened = CountDownLatch(6)
+      val openedAt = CopyOnWriteArrayList<Long>()
+      val eventSource =
+        EventSource(
+          { headers ->
+            createRequest(
+              server.url("/test").toString(),
+              headers,
+              onStart = {
+                openedAt += System.nanoTime()
+                opened.countDown()
+              },
+            )
+          },
+          SundayHttpProblem.Factory,
+          retryTime = Duration.ofMillis(100),
+        )
+
+      eventSource.use {
+        eventSource.connect()
+
+        expectThat(opened.await(4, SECONDS)).isTrue()
+        val finalReconnectDelay = Duration.ofNanos(openedAt[5] - openedAt[4])
+        expectThat(finalReconnectDelay).isLessThan(Duration.ofMillis(700))
+      }
+    }
+  }
+
+  @Test
+  fun `non-success response fails without reconnecting`() {
+    val server = MockWebServer()
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(400)
+        .addHeader(CONTENT_TYPE, Problem),
+    )
+    server.start()
+    server.use {
+      val eventSource =
+        EventSource(
+          { headers -> createRequest(server.url("/test").toString(), headers) },
+          SundayHttpProblem.Factory,
+          retryTime = Duration.ofMillis(50),
+        )
+
+      val errored = CountDownLatch(1)
+      eventSource.onError = { errored.countDown() }
+
+      eventSource.use {
+        eventSource.connect()
+
+        expectThat(errored.await(3, SECONDS)).isTrue()
+        expectThat(eventSource.readyState).isEqualTo(EventSource.ReadyState.Closed)
+        expectThat(server.takeRequest(250, MILLISECONDS)).isNotNull()
+        expectThat(server.takeRequest(250, MILLISECONDS)).isNull()
+      }
+    }
+  }
+
+  @Test
+  fun `no-content response closes without reconnecting`() {
+    val server = MockWebServer()
+    server.enqueue(MockResponse().setResponseCode(204))
+    server.start()
+    server.use {
+      val eventSource =
+        EventSource(
+          { headers -> createRequest(server.url("/test").toString(), headers) },
+          SundayHttpProblem.Factory,
+          retryTime = Duration.ofMillis(50),
+        )
+
+      val errored = CountDownLatch(1)
+      eventSource.onError = { errored.countDown() }
+
+      eventSource.use {
+        eventSource.connect()
+
+        expectThat(server.takeRequest(3, SECONDS)).isNotNull()
+        expectThat(server.takeRequest(250, MILLISECONDS)).isNull()
+        expectThat(errored.await(250, MILLISECONDS)).isFalse()
+        expectThat(eventSource.readyState).isEqualTo(EventSource.ReadyState.Closed)
       }
     }
   }

--- a/core/src/testFixtures/kotlin/io/outfoxx/sunday/test/EventSourceTest.kt
+++ b/core/src/testFixtures/kotlin/io/outfoxx/sunday/test/EventSourceTest.kt
@@ -439,7 +439,7 @@ abstract class EventSourceTest {
         .setBody(
           """
           |retry: -1
-          |retry-max: -1
+          |retry-max: 0
           |keepalive: 0
           |data: some test data
           |
@@ -796,6 +796,11 @@ abstract class EventSourceTest {
           3,
         ),
     )
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .addHeader(CONTENT_TYPE, EventStream),
+    )
     server.start()
     server.use {
       val connected = CountDownLatch(1)
@@ -804,20 +809,23 @@ abstract class EventSourceTest {
         EventSource(
           { headers ->
             createRequest(server.url("/test").toString(), headers, connected::countDown) {
-              println("### CANCELED")
               canceled.countDown()
             }
           },
           SundayHttpProblem.Factory,
+          retryTime = Duration.ofMillis(50),
         )
 
       eventSource.connect()
 
       expectThat(connected.await(12, SECONDS)).isTrue()
+      expectThat(server.takeRequest(3, SECONDS)).isNotNull()
 
       eventSource.close()
 
       expectThat(canceled.await(12, SECONDS)).isTrue()
+      expectThat(eventSource.readyState).isEqualTo(EventSource.ReadyState.Closed)
+      expectThat(server.takeRequest(250, MILLISECONDS)).isNull()
     }
   }
 

--- a/jdk/src/main/kotlin/io/outfoxx/sunday/jdk/JdkTransport.kt
+++ b/jdk/src/main/kotlin/io/outfoxx/sunday/jdk/JdkTransport.kt
@@ -67,7 +67,7 @@ class JdkTransport(
   override val mediaTypeDecoders: MediaTypeDecoders = MediaTypeDecoders.default,
   override val pathEncoders: Map<KClass<*>, PathEncoder> = PathEncoders.default,
   private val requestTimeout: Duration = requestTimeoutDefault,
-  private val eventRequestTimeout: Duration = EventSource.eventTimeoutDefault,
+  private val eventRequestTimeout: Duration? = null,
 ) : Transport<JdkRequest>(),
   Closeable {
 
@@ -170,15 +170,17 @@ class JdkTransport(
       requestBodyPublisher = BodyPublishers.ofByteArray(byteArrayOf())
     }
 
+    val timeout =
+      when (purpose) {
+        RequestPurpose.Normal -> requestTimeout
+        RequestPurpose.Events -> eventRequestTimeout
+      }
+    timeout?.let(requestBuilder::timeout)
+
     val request =
       requestBuilder
         .method(method.name, requestBodyPublisher ?: BodyPublishers.noBody())
-        .timeout(
-          when (purpose) {
-            RequestPurpose.Normal -> requestTimeout
-            RequestPurpose.Events -> eventRequestTimeout
-          },
-        ).build()
+        .build()
 
     logger.debug("Built request: {}", request)
 


### PR DESCRIPTION
## Summary

- align EventSource retries on a 500 ms exponential backoff with bounded jitter and a 30x default cap
- support server-advertised `retry-max:` and `keepalive:` controls, ignoring non-positive caps and preserving explicit application timeout precedence
- disable silence-based timeouts by default and count comment-only blocks as stream activity
- treat HTTP 204, other non-success statuses, and explicit client cancellation as terminal instead of entering the reconnect loop

## Root cause

The runtime used a quadratic reconnect curve and an unconditional event timeout, while response handling reported non-success statuses but still transitioned the source to open. This made retry timing inconsistent with sibling runtimes, treated legitimate stream silence as failure, and allowed terminal HTTP responses to spin the retry loop.

## Validation

- `./gradlew check`
- shared EventSource tests against both JDK and OkHttp transports
- focused parser and reconnect-policy unit tests

Closes #50
